### PR TITLE
Linting the codebase to be PEP 8 compliant with black for readibility 

### DIFF
--- a/clinguin/__init__.py
+++ b/clinguin/__init__.py
@@ -16,18 +16,19 @@ from .parse_input import ArgumentParser
 from .server_helper import start as server_start
 from .client_helper import start as client_start
 
+
 def argsToDictConvert(args_dict, timestamp, name_prefix=""):
     """
     Converts the ''external-logger-config'' representation into an internal one
     """
     log_dict = {}
-    log_dict['file_enabled'] = args_dict[name_prefix + 'log_enable_file']
-    log_dict['shell_disabled'] = args_dict[name_prefix + 'log_disable_shell']
-    log_dict['name'] = args_dict[name_prefix + 'logger_name']
-    log_dict['level'] = args_dict[name_prefix + 'log_level']
-    log_dict['format_shell'] = args_dict[name_prefix + 'log_format_shell']
-    log_dict['format_file'] = args_dict[name_prefix + 'log_format_file']
-    log_dict['timestamp'] = timestamp
+    log_dict["file_enabled"] = args_dict[name_prefix + "log_enable_file"]
+    log_dict["shell_disabled"] = args_dict[name_prefix + "log_disable_shell"]
+    log_dict["name"] = args_dict[name_prefix + "logger_name"]
+    log_dict["level"] = args_dict[name_prefix + "log_level"]
+    log_dict["format_shell"] = args_dict[name_prefix + "log_format_shell"]
+    log_dict["format_file"] = args_dict[name_prefix + "log_format_file"]
+    log_dict["timestamp"] = timestamp
 
     return log_dict
 
@@ -43,18 +44,16 @@ def main():
     args_dict = vars(args)
 
     timestamp = datetime.now().strftime("%Y-%m-%d::%H:%M:%S")
-    
 
-    if args.process == 'server':
+    if args.process == "server":
         log_dict = argsToDictConvert(args_dict, timestamp)
 
         args_copy = copy.deepcopy(args)
         args_copy.log_args = log_dict
-        server = threading.Thread(
-            target=server_start, args=[args_copy])
+        server = threading.Thread(target=server_start, args=[args_copy])
         server.start()
 
-    elif args.process == 'client':
+    elif args.process == "client":
         log_dict = argsToDictConvert(args_dict, timestamp)
 
         args_copy = copy.deepcopy(args)
@@ -62,14 +61,13 @@ def main():
 
         client_start(args_copy)
 
-    elif args.process == 'client-server':
+    elif args.process == "client-server":
 
         server_log_dict = argsToDictConvert(args_dict, timestamp, name_prefix="server_")
         args_copy = copy.deepcopy(args)
         args_copy.log_args = server_log_dict
 
-        server = threading.Thread(
-            target=server_start, args=[args_copy])
+        server = threading.Thread(target=server_start, args=[args_copy])
         server.start()
 
         client_log_dict = argsToDictConvert(args_dict, timestamp, name_prefix="client_")
@@ -78,6 +76,3 @@ def main():
         args_copy.log_args = client_log_dict
 
         client_start(args_copy)
-
-
-

--- a/clinguin/client/__init__.py
+++ b/clinguin/client/__init__.py
@@ -6,7 +6,9 @@ from .api.frontend_policy_dto import FrontendPolicyDto
 from .presentation.abstract_frontend import AbstractFrontend
 from .application.client_base import ClientBase
 
-__all__ = [AbstractFrontend.__name__, ClientBase.__name__, Api.__name__, FrontendPolicyDto.__name__]
-
-
-
+__all__ = [
+    AbstractFrontend.__name__,
+    ClientBase.__name__,
+    Api.__name__,
+    FrontendPolicyDto.__name__,
+]

--- a/clinguin/client/api/api.py
+++ b/clinguin/client/api/api.py
@@ -10,9 +10,10 @@ from clinguin.utils import Logger
 
 from .frontend_policy_dto import FrontendPolicyDto
 
-class Api:  
+
+class Api:
     """
-    The API class is responsible for handling API calls, i.e. sending requests and receiving the responses. 
+    The API class is responsible for handling API calls, i.e. sending requests and receiving the responses.
     For this two methods exists - GET and POST.
     This Api sends by default requests to the url:http://127.0.0.1:8000/
     """
@@ -38,12 +39,15 @@ class Api:
             self._logger.error("<<<END-STACKTRACE>>>")
             return (-2, "")
 
-
-
     def post(self, endpoint, body: FrontendPolicyDto):
         try:
-            self._logger.info("<-- POST to %s%s   %s", str(self.base_url), str(endpoint), str(body.function))
-            
+            self._logger.info(
+                "<-- POST to %s%s   %s",
+                str(self.base_url),
+                str(endpoint),
+                str(body.function),
+            )
+
             data = body.to_JSON()
             r = httpx.post(self.base_url + endpoint, data=data, timeout=10000)
             self._logger.debug(r.json())
@@ -57,6 +61,3 @@ class Api:
             traceback.print_exc()
             self._logger.error("<<<END-STACKTRACE>>>")
             return (-2, "")
-
-
-            

--- a/clinguin/client/api/frontend_policy_dto.py
+++ b/clinguin/client/api/frontend_policy_dto.py
@@ -3,6 +3,7 @@ Module contains the FrontendPolicyDto class
 """
 import json
 
+
 class FrontendPolicyDto:
     """
     Dto class for encapsulating the json that shall be sent to the backend that handles the callbacks.

--- a/clinguin/client/application/client_base.py
+++ b/clinguin/client/application/client_base.py
@@ -8,7 +8,8 @@ from clinguin.utils import CaseConverter, Logger
 from clinguin.client.api.api import Api
 from clinguin.client.api.frontend_policy_dto import FrontendPolicyDto
 
-class ClientBase:   
+
+class ClientBase:
     """
     ClientBase is the ''base'' of the client. It contains the logic which is responsible for connecting to the server, what to do in case of errors, forward the Json to the correct GUI, etc.
     """
@@ -30,10 +31,9 @@ class ClientBase:
         (status_code, response) = self.api.get("")
         if status_code == 200:
             self.draw(response)
-            self.frontend_generator.draw(response['children'][0]['id'])
+            self.frontend_generator.draw(response["children"][0]["id"])
         else:
-            self._logger.error(
-                "Connection error, status code: %s", str(status_code))
+            self._logger.error("Connection error, status code: %s", str(status_code))
 
             self.connected = False
             self.connect()
@@ -59,10 +59,10 @@ class ClientBase:
             response (dict): Json from which one can draw the GUI.
         """
 
-        children = response['children']
+        children = response["children"]
 
         for child in children:
-            snake_case_name = child['type']
+            snake_case_name = child["type"]
             camel_case_name = CaseConverter.snake_case_to_camel_case(snake_case_name)
 
             method = None
@@ -74,24 +74,21 @@ class ClientBase:
 
             if method and callable(method):
                 method(
-                    child['id'],
-                    child['parent'],
-                    child['attributes'],
-                    child['callbacks'])
+                    child["id"],
+                    child["parent"],
+                    child["attributes"],
+                    child["callbacks"],
+                )
                 self.base_engine(child)
             else:
-                self._logger.error(
-                    "Could not find element type: %s", child['type'])
+                self._logger.error("Could not find element type: %s", child["type"])
 
     def post_with_policy(self, click_policy):
         (status_code, json) = self.api.post("backend", FrontendPolicyDto(click_policy))
         if status_code == 200:
             self.draw(json)
         else:
-            self._logger.error(
-                "Connection error, status code: %s", str(status_code))
+            self._logger.error("Connection error, status code: %s", str(status_code))
 
             self.connected = False
             self.connect()
-
-

--- a/clinguin/client/presentation/abstract_frontend.py
+++ b/clinguin/client/presentation/abstract_frontend.py
@@ -5,6 +5,7 @@ import logging
 
 from clinguin.utils import CustomArgs, Logger
 
+
 class AbstractFrontend(CustomArgs):
     """
     Superclass from where every specialized gui class inherits from (e.g. TkinterFrontend). Defines the available elements.
@@ -15,44 +16,142 @@ class AbstractFrontend(CustomArgs):
         self._logger = logging.getLogger(Logger.client_logger_name)
         self._base_engine = base_engine
 
-
     @classmethod
     def available_syntax(cls, show_level):
         print(show_level)
         return ""
 
     def window(self, id, parent, attributes, callbacks):
-        print("WINDOW: " + str(id) + "::" + str(parent) + "::" + str(attributes) + "::" + str(callbacks))
+        print(
+            "WINDOW: "
+            + str(id)
+            + "::"
+            + str(parent)
+            + "::"
+            + str(attributes)
+            + "::"
+            + str(callbacks)
+        )
 
     def container(self, id, parent, attributes, callbacks):
-        print("CONTAINER: " + str(id) + "::" + str(parent) + "::" + str(attributes) + "::" + str(callbacks))
+        print(
+            "CONTAINER: "
+            + str(id)
+            + "::"
+            + str(parent)
+            + "::"
+            + str(attributes)
+            + "::"
+            + str(callbacks)
+        )
 
     def dropdown_menu(self, id, parent, attributes, callbacks):
-        print("DROPDOWNMENU: " + str(id) + "::" + str(parent) + "::" + str(attributes) + "::" + str(callbacks))
+        print(
+            "DROPDOWNMENU: "
+            + str(id)
+            + "::"
+            + str(parent)
+            + "::"
+            + str(attributes)
+            + "::"
+            + str(callbacks)
+        )
 
     def dropdown_menu_item(self, id, parent, attributes, callbacks):
-        print("DROPDOWNMENUITEM: " + str(id) + "::" + str(parent) + "::" + str(attributes) + "::" + str(callbacks))
+        print(
+            "DROPDOWNMENUITEM: "
+            + str(id)
+            + "::"
+            + str(parent)
+            + "::"
+            + str(attributes)
+            + "::"
+            + str(callbacks)
+        )
 
     def label(self, id, parent, attributes, callbacks):
-        print("LABEL: " + str(id) + "::" + str(parent) + "::" + str(attributes) + "::" + str(callbacks))
+        print(
+            "LABEL: "
+            + str(id)
+            + "::"
+            + str(parent)
+            + "::"
+            + str(attributes)
+            + "::"
+            + str(callbacks)
+        )
 
     def button(self, id, parent, attributes, callbacks):
-        print("BUTTON: " + str(id) + "::" + str(parent) + "::" + str(attributes) + "::" + str(callbacks))
+        print(
+            "BUTTON: "
+            + str(id)
+            + "::"
+            + str(parent)
+            + "::"
+            + str(attributes)
+            + "::"
+            + str(callbacks)
+        )
 
     def menu_bar(self, id, parent, attributes, callbacks):
-        print("MENUBAR: " + str(id) + "::" + str(parent) + "::" + str(attributes) + "::" + str(callbacks))
+        print(
+            "MENUBAR: "
+            + str(id)
+            + "::"
+            + str(parent)
+            + "::"
+            + str(attributes)
+            + "::"
+            + str(callbacks)
+        )
 
     def menu_bar_section(self, id, parent, attributes, callbacks):
-        print("MENUBARSECTION: " + str(id) + "::" + str(parent) + "::" + str(attributes) + "::" + str(callbacks))
+        print(
+            "MENUBARSECTION: "
+            + str(id)
+            + "::"
+            + str(parent)
+            + "::"
+            + str(attributes)
+            + "::"
+            + str(callbacks)
+        )
 
     def menu_bar_section_item(self, id, parent, attributes, callbacks):
-        print("MENUBARSECTIONITEM: " + str(id) + "::" + str(parent) + "::" + str(attributes) + "::" + str(callbacks))
+        print(
+            "MENUBARSECTIONITEM: "
+            + str(id)
+            + "::"
+            + str(parent)
+            + "::"
+            + str(attributes)
+            + "::"
+            + str(callbacks)
+        )
 
     def message(self, id, parent, attributes, callbacks):
-        print("MESSAGE: " + str(id) + "::" + str(parent) + "::" + str(attributes) + "::" + str(callbacks))
+        print(
+            "MESSAGE: "
+            + str(id)
+            + "::"
+            + str(parent)
+            + "::"
+            + str(attributes)
+            + "::"
+            + str(callbacks)
+        )
 
     def canvas(self, id, parent, attributes, callbacks):
-        print("CANVAS: " + str(id) + "::" + str(parent) + "::" + str(attributes) + "::" + str(callbacks))
+        print(
+            "CANVAS: "
+            + str(id)
+            + "::"
+            + str(parent)
+            + "::"
+            + str(attributes)
+            + "::"
+            + str(callbacks)
+        )
 
     def draw(self, id):
         print("DRAW" + "::" + str(id))

--- a/clinguin/client/presentation/frontends/ipython_frontend/ipython_frontend.py
+++ b/clinguin/client/presentation/frontends/ipython_frontend/ipython_frontend.py
@@ -3,6 +3,7 @@ Module that contains the IPythonFrontendClass
 """
 from clinguin.client.presentation.abstract_frontend import AbstractFrontend
 
+
 class IPythonFrontend(AbstractFrontend):
     """
     Not yet implemented!

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/__init__.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/__init__.py
@@ -14,5 +14,17 @@ from .menu_bar_section_item import MenuBarSectionItem
 from .message import Message
 from .canvas import Canvas
 
-__all__ = [RootCmp.__name__, Window.__name__, Container.__name__, Dropdownmenu.__name__, DropdownmenuItem.__name__, Label.__name__, Button.__name__, MenuBar.__name__, MenuBarSection.__name__, MenuBarSectionItem.__name__, Message.__name__, Canvas.__name__]
-
+__all__ = [
+    RootCmp.__name__,
+    Window.__name__,
+    Container.__name__,
+    Dropdownmenu.__name__,
+    DropdownmenuItem.__name__,
+    Label.__name__,
+    Button.__name__,
+    MenuBar.__name__,
+    MenuBarSection.__name__,
+    MenuBarSectionItem.__name__,
+    Message.__name__,
+    Canvas.__name__,
+]

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/button.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/button.py
@@ -5,105 +5,123 @@ import tkinter as tk
 
 from .root_cmp import *
 
+
 class Button(RootCmp, LayoutFollower, ConfigureSize, ConfigureFont):
     """
     A button is a element, which is generally regarded as an active element, so actions are executed. For available attributes see syntax definition. Implementation wise it is similarly implemented as the Label and Dropdownmenu - to make it work for layouting, the actual button is hidden the the element is actually a tkinter frame (therefore self._element is a frame, whereas self._button is the button).
     """
+
     def __init__(self, args, id, parent, attributes, callbacks, base_engine):
         super().__init__(args, id, parent, attributes, callbacks, base_engine)
-        
+
         self._button = None
 
     def _init_element(self, elements):
 
         button_frame = tk.Frame(elements[str(self._parent)].get_element())
-        
+
         self._button = tk.Button(button_frame)
         self._configure_font_element = self._button
 
         return button_frame
 
     @classmethod
-    def _get_attributes(cls, attributes = None):
+    def _get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
         # Label/Text
-        attributes[AttributeNames.label] = {"value":"", "value_type" : StringType}
+        attributes[AttributeNames.label] = {"value": "", "value_type": StringType}
         # Color
-        attributes[AttributeNames.backgroundcolor] = {"value":"white", "value_type" : ColorType}
-        attributes[AttributeNames.foregroundcolor] = {"value":"black", "value_type" : ColorType}
+        attributes[AttributeNames.backgroundcolor] = {
+            "value": "white",
+            "value_type": ColorType,
+        }
+        attributes[AttributeNames.foregroundcolor] = {
+            "value": "black",
+            "value_type": ColorType,
+        }
         # Interactive-Attributes
-        attributes[AttributeNames.onhover] = {"value":False, "value_type" : BooleanType}
-        attributes[AttributeNames.onhover_background_color] = {"value":"white", "value_type" : ColorType}
-        attributes[AttributeNames.onhover_foreground_color] = {"value":"black", "value_type" : ColorType}
+        attributes[AttributeNames.onhover] = {"value": False, "value_type": BooleanType}
+        attributes[AttributeNames.onhover_background_color] = {
+            "value": "white",
+            "value_type": ColorType,
+        }
+        attributes[AttributeNames.onhover_foreground_color] = {
+            "value": "black",
+            "value_type": ColorType,
+        }
 
         return attributes
 
     @classmethod
-    def _get_callbacks(cls, callbacks = None):
+    def _get_callbacks(cls, callbacks=None):
         if callbacks is None:
             callbacks = {}
 
-        callbacks[CallbackNames.click] = {"policy":None, "policy_type" : SymbolType}
+        callbacks[CallbackNames.click] = {"policy": None, "policy_type": SymbolType}
 
         return callbacks
 
-    #----------------------------------------------------------------------------------------------
-    #-----Attributes----
-    #----------------------------------------------------------------------------------------------
+    # ----------------------------------------------------------------------------------------------
+    # -----Attributes----
+    # ----------------------------------------------------------------------------------------------
 
     def _set_label_text(self, elements):
         text = self._attributes[AttributeNames.label]["value"]
-        self._button.configure(text = text)
+        self._button.configure(text=text)
 
-    def _set_background_color(self, elements, key = AttributeNames.backgroundcolor):
+    def _set_background_color(self, elements, key=AttributeNames.backgroundcolor):
         value = self._attributes[key]["value"]
-        self._button.configure(background = value)
+        self._button.configure(background=value)
 
-    def _set_foreground_color(self, elements, key = AttributeNames.foregroundcolor):
+    def _set_foreground_color(self, elements, key=AttributeNames.foregroundcolor):
         value = self._attributes[key]["value"]
-        self._button.configure(foreground = value)
+        self._button.configure(foreground=value)
 
-    def _set_on_hover(self, elements): 
+    def _set_on_hover(self, elements):
         on_hover = self._attributes[AttributeNames.onhover]["value"]
-        on_hover_background_color = self._attributes[AttributeNames.onhover_background_color]["value"]
+        on_hover_background_color = self._attributes[
+            AttributeNames.onhover_background_color
+        ]["value"]
 
-        on_hover_foreground_color = self._attributes[AttributeNames.onhover_foreground_color]["value"]
+        on_hover_foreground_color = self._attributes[
+            AttributeNames.onhover_foreground_color
+        ]["value"]
 
         if on_hover:
+
             def enter(event):
                 if on_hover_background_color != "":
-                    self._set_background_color(elements, key = AttributeNames.onhover_background_color)
+                    self._set_background_color(
+                        elements, key=AttributeNames.onhover_background_color
+                    )
                 if on_hover_foreground_color != "":
-                    self._set_foreground_color(elements, key = AttributeNames.onhover_foreground_color)
+                    self._set_foreground_color(
+                        elements, key=AttributeNames.onhover_foreground_color
+                    )
 
             def leave(event):
                 self._set_background_color(elements)
                 self._set_foreground_color(elements)
-    
-            self._button.bind('<Enter>', enter)
-            self._button.bind('<Leave>', leave)
 
-    #----------------------------------------------------------------------------------------------
-    #-----Actions----
-    #----------------------------------------------------------------------------------------------
-       
+            self._button.bind("<Enter>", enter)
+            self._button.bind("<Leave>", leave)
+
+    # ----------------------------------------------------------------------------------------------
+    # -----Actions----
+    # ----------------------------------------------------------------------------------------------
+
     def _define_click_event(self, elements):
         key = CallbackNames.click
         if self._callbacks[key] and self._callbacks[key]["policy"]:
+
             def clickEvent(event):
                 self._base_engine.post_with_policy(self._callbacks[key]["policy"])
 
-            self._button.bind('<Button-1>', clickEvent)
+            self._button.bind("<Button-1>", clickEvent)
 
     def _add_component_to_elements(self, elements):
-        self._button.pack(expand=True, fill='both')
+        self._button.pack(expand=True, fill="both")
 
         elements[str(self._id)] = self
-
-
-
-
-
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/canvas.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/canvas.py
@@ -10,6 +10,7 @@ import PIL.Image as TImage
 
 from .root_cmp import *
 
+
 class Canvas(RootCmp, LayoutFollower, ConfigureSize):
     """
     The canvas class resembles a element, which is generally regarded as an ''empty sheet of paper'', so there is an area, where one can display images, draw something or does something similar. One can look up what actual options are available through the syntax-definition. Implementation wise it is similarly implemented to the label, button and dropdownmenu.
@@ -20,7 +21,6 @@ class Canvas(RootCmp, LayoutFollower, ConfigureSize):
 
         self._canvas = None
         self._image = None
-        
 
     def _init_element(self, elements):
         canvas_frame = tk.Frame(elements[str(self._parent)].get_element())
@@ -30,13 +30,13 @@ class Canvas(RootCmp, LayoutFollower, ConfigureSize):
         return canvas_frame
 
     @classmethod
-    def _get_attributes(cls, attributes = None):
+    def _get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.image] = {"value":"", "value_type" : ImageType}
-        attributes[AttributeNames.image_path] = {"value":"", "value_type" : PathType}
-        attributes[AttributeNames.resize] = {"value": True, "value_type" : BooleanType}
+        attributes[AttributeNames.image] = {"value": "", "value_type": ImageType}
+        attributes[AttributeNames.image_path] = {"value": "", "value_type": PathType}
+        attributes[AttributeNames.resize] = {"value": True, "value_type": BooleanType}
         return attributes
 
     def _set_image(self, elements):
@@ -45,54 +45,66 @@ class Canvas(RootCmp, LayoutFollower, ConfigureSize):
         image_file = self._attributes[AttributeNames.image_path]["value"]
 
         if image_base64 != "" and image_file != "":
-            self._logger.error("One cannot set both attributes %s and %s for the same canvas with id %s", AttributeNames.image, AttributeNames.image_path, str(self._id))
+            self._logger.error(
+                "One cannot set both attributes %s and %s for the same canvas with id %s",
+                AttributeNames.image,
+                AttributeNames.image_path,
+                str(self._id),
+            )
 
         elif image_base64 == "" and image_file != "":
             try:
-                
+
                 image_open = TImage.open(image_file)
 
                 height = self._attributes[AttributeNames.height]["value"]
                 width = self._attributes[AttributeNames.width]["value"]
                 resize_flag = self._attributes[AttributeNames.resize]["value"]
-                
+
                 should_resize = resize_flag and height > 0 and width > 0
-                
+
                 if should_resize:
                     image_open = image_open.resize((width, height))
 
                 tkinter_image = ImageTk.PhotoImage(image_open, master=self._canvas)
 
-                self._canvas.create_image(0,0,anchor=tk.NW, image=tkinter_image)
+                self._canvas.create_image(0, 0, anchor=tk.NW, image=tkinter_image)
 
                 # DO NOT DELETE THIS SEEMINGLY UNECESSARY LINE (this is due to a tkinter bug)
                 self._image = tkinter_image
             except Exception as e:
                 self._logger.error(e)
-                self._logger.error("Could not render image (likely the provided file <%s>is not a valid image).", image_file)
+                self._logger.error(
+                    "Could not render image (likely the provided file <%s>is not a valid image).",
+                    image_file,
+                )
 
         elif image_base64 != "" and image_file == "":
             try:
-                image_initial_bytes = image_base64.encode('utf-8')
+                image_initial_bytes = image_base64.encode("utf-8")
                 image_decoded = base64.b64decode(image_initial_bytes)
 
                 image_bytes = io.BytesIO(image_decoded)
                 image_open = TImage.open(image_bytes)
 
-                image_open = image_open.resize((self._attributes[AttributeNames.width]["value"], self._attributes[AttributeNames.width]["value"]))
+                image_open = image_open.resize(
+                    (
+                        self._attributes[AttributeNames.width]["value"],
+                        self._attributes[AttributeNames.width]["value"],
+                    )
+                )
                 tkinter_image = ImageTk.PhotoImage(image_open, master=self._canvas)
 
-
-                self._canvas.create_image(0,0,anchor=tk.NW, image=tkinter_image)
+                self._canvas.create_image(0, 0, anchor=tk.NW, image=tkinter_image)
 
                 # DO NOT DELETE THIS SEEMINGLY UNECESSARY LINE
                 self._image = tkinter_image
             except Exception:
-                self._logger.error("Could not render image (likely Base64 encoding is wrong).")
-            
+                self._logger.error(
+                    "Could not render image (likely Base64 encoding is wrong)."
+                )
 
     def _add_component_to_elements(self, elements):
-        self._canvas.pack(expand=True, fill='both')
+        self._canvas.pack(expand=True, fill="both")
 
         elements[str(self._id)] = self
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/container.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/container.py
@@ -5,7 +5,10 @@ import tkinter as tk
 
 from .root_cmp import *
 
-class Container(RootCmp, LayoutFollower, LayoutController, ConfigureSize, ConfigureBorder):
+
+class Container(
+    RootCmp, LayoutFollower, LayoutController, ConfigureSize, ConfigureBorder
+):
     """
     The container is a generic element which can be used for layouting, hovering effects or even callbacks. Generally it is recommended to use it as a ''container'' for multiple other elements, e.g. labels, buttons, etc.
     """
@@ -15,65 +18,84 @@ class Container(RootCmp, LayoutFollower, LayoutController, ConfigureSize, Config
         return container
 
     @classmethod
-    def _get_attributes(cls, attributes = None):
+    def _get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.backgroundcolor] = {"value":"white", "value_type" : ColorType, "description": "CUSTOM-BACKGROUND-COLOR-DESCRIPTION <- Now normal:" + AttributeNames.descriptions[AttributeNames.backgroundcolor]}
+        attributes[AttributeNames.backgroundcolor] = {
+            "value": "white",
+            "value_type": ColorType,
+            "description": "CUSTOM-BACKGROUND-COLOR-DESCRIPTION <- Now normal:"
+            + AttributeNames.descriptions[AttributeNames.backgroundcolor],
+        }
         # Interactive-Attributes
-        attributes[AttributeNames.onhover] = {"value":False, "value_type" : BooleanType}
-        attributes[AttributeNames.onhover_background_color] = {"value":"", "value_type" : ColorType}
-        attributes[AttributeNames.onhover_border_color] = {"value":"", "value_type" : ColorType}
+        attributes[AttributeNames.onhover] = {"value": False, "value_type": BooleanType}
+        attributes[AttributeNames.onhover_background_color] = {
+            "value": "",
+            "value_type": ColorType,
+        }
+        attributes[AttributeNames.onhover_border_color] = {
+            "value": "",
+            "value_type": ColorType,
+        }
 
         return attributes
 
     @classmethod
-    def _get_callbacks(cls, callbacks = None):
+    def _get_callbacks(cls, callbacks=None):
         if callbacks is None:
             callbacks = {}
 
-        callbacks["click"] = {"policy":None, "policy_type" : SymbolType}
+        callbacks["click"] = {"policy": None, "policy_type": SymbolType}
 
         return callbacks
 
-    #----------------------------------------------------------------------------------------------
-    #-----Attributes----
-    #----------------------------------------------------------------------------------------------
+    # ----------------------------------------------------------------------------------------------
+    # -----Attributes----
+    # ----------------------------------------------------------------------------------------------
 
-    def _set_background_color(self, elements, key = AttributeNames.backgroundcolor):
+    def _set_background_color(self, elements, key=AttributeNames.backgroundcolor):
         value = self._attributes[key]["value"]
-        self._element.configure(background = value)
-    def _set_on_hover(self, elements): 
+        self._element.configure(background=value)
+
+    def _set_on_hover(self, elements):
         on_hover = self._attributes[AttributeNames.onhover]["value"]
-        on_hover_color = self._attributes[AttributeNames.onhover_background_color]["value"]
-        on_hover_border_color = self._attributes[AttributeNames.onhover_border_color]["value"]
+        on_hover_color = self._attributes[AttributeNames.onhover_background_color][
+            "value"
+        ]
+        on_hover_border_color = self._attributes[AttributeNames.onhover_border_color][
+            "value"
+        ]
 
         if on_hover:
+
             def enter(event):
                 if on_hover_color != "":
-                    self._set_background_color(elements, key = AttributeNames.onhover_background_color)
+                    self._set_background_color(
+                        elements, key=AttributeNames.onhover_background_color
+                    )
                 if on_hover_border_color != "":
-                    self._set_border_background_color(elements, key = AttributeNames.onhover_border_color)
+                    self._set_border_background_color(
+                        elements, key=AttributeNames.onhover_border_color
+                    )
 
             def leave(event):
-                self._set_background_color(elements, key = AttributeNames.backgroundcolor)
-                self._set_border_background_color(elements, key = AttributeNames.border_color)
-            
-            self._element.bind('<Enter>', enter)
-            self._element.bind('<Leave>', leave)
- 
-    #----------------------------------------------------------------------------------------------
-    #-----Actions----
-    #----------------------------------------------------------------------------------------------
-       
-    def _define_click_event(self, elements, key = CallbackNames.click):
+                self._set_background_color(elements, key=AttributeNames.backgroundcolor)
+                self._set_border_background_color(
+                    elements, key=AttributeNames.border_color
+                )
+
+            self._element.bind("<Enter>", enter)
+            self._element.bind("<Leave>", leave)
+
+    # ----------------------------------------------------------------------------------------------
+    # -----Actions----
+    # ----------------------------------------------------------------------------------------------
+
+    def _define_click_event(self, elements, key=CallbackNames.click):
         if self._callbacks[key] and self._callbacks[key]["policy"]:
+
             def dropdownmenuitemClick(event):
                 self._base_engine.assume(self._callbacks[key]["policy"])
 
-            self._element.bind('<Button-1>', dropdownmenuitemClick)
-
-
-
-
-
+            self._element.bind("<Button-1>", dropdownmenuitemClick)

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/dropdownmenu.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/dropdownmenu.py
@@ -5,16 +5,17 @@ import tkinter as tk
 
 from .root_cmp import *
 
+
 class Dropdownmenu(RootCmp, LayoutFollower, ConfigureSize):
     """
     The dropdownmenu is the master component for a dropdownmenu, i.e. dropdownmenu-items must be children of it. For available attributes see syntax definition. Implementation wise it is similarly implemented as the Label and Button - to make it work for layouting, the actual dropdownmenu is hidden and the element is actually a tkinter frame (therefore self._element is a frame, whereas self._menu is the dropdownmenu).
     """
+
     def __init__(self, args, id, parent, attributes, callbacks, base_engine):
         super().__init__(args, id, parent, attributes, callbacks, base_engine)
-        
+
         self._menu = None
         self._variable = None
-
 
     def _init_element(self, elements):
 
@@ -32,27 +33,42 @@ class Dropdownmenu(RootCmp, LayoutFollower, ConfigureSize):
         return self._variable
 
     @classmethod
-    def _get_attributes(cls, attributes = None):
+    def _get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.backgroundcolor] = {"value":"white", "value_type" : ColorType}
-        attributes[AttributeNames.foregroundcolor] = {"value":"black", "value_type" : ColorType}
+        attributes[AttributeNames.backgroundcolor] = {
+            "value": "white",
+            "value_type": ColorType,
+        }
+        attributes[AttributeNames.foregroundcolor] = {
+            "value": "black",
+            "value_type": ColorType,
+        }
         # Interactive-Attributes
-        attributes[AttributeNames.onhover] = {"value":False, "value_type": BooleanType}
-        attributes[AttributeNames.onhover_background_color] = {"value":"white", "value_type" : ColorType}
-        attributes[AttributeNames.onhover_foreground_color] = {"value":"black", "value_type" : ColorType}
-        
-        attributes[AttributeNames.selected] = {"value":"", "value_type" : StringType}
- 
+        attributes[AttributeNames.onhover] = {"value": False, "value_type": BooleanType}
+        attributes[AttributeNames.onhover_background_color] = {
+            "value": "white",
+            "value_type": ColorType,
+        }
+        attributes[AttributeNames.onhover_foreground_color] = {
+            "value": "black",
+            "value_type": ColorType,
+        }
+
+        attributes[AttributeNames.selected] = {"value": "", "value_type": StringType}
+
         return attributes
 
     @classmethod
-    def _get_callbacks(cls, callbacks = None):
+    def _get_callbacks(cls, callbacks=None):
         if callbacks is None:
-            callbacks =  {}
+            callbacks = {}
 
-        callbacks[CallbackNames.clear] = {"policy":"remove_assumption_signature", "policy_type" : SymbolType}
+        callbacks[CallbackNames.clear] = {
+            "policy": "remove_assumption_signature",
+            "policy_type": SymbolType,
+        }
 
         return callbacks
 
@@ -64,56 +80,65 @@ class Dropdownmenu(RootCmp, LayoutFollower, ConfigureSize):
             if click_policy is not None:
                 self._base_engine.post_with_policy(click_policy)
         else:
-            self._logger.warning("Could not set variable for dropdownmenu. Item id: %s, dropdown-menu-id: %s", str(id), str(parent_id))
+            self._logger.warning(
+                "Could not set variable for dropdownmenu. Item id: %s, dropdown-menu-id: %s",
+                str(id),
+                str(parent_id),
+            )
 
     def _dropdown_clear(self, click_policy):
         variable = self.get_variable()
         variable.set("")
         self._base_engine.post_with_policy(click_policy)
 
-    def _define_clear_event(self, elements, key = CallbackNames.clear):
+    def _define_clear_event(self, elements, key=CallbackNames.clear):
         def change(*args):
-            if self._variable.get()=="":
+            if self._variable.get() == "":
                 self._logger.info("Will remove previous selections")
-                self._dropdown_clear(self._callbacks[key]['policy'])
+                self._dropdown_clear(self._callbacks[key]["policy"])
+
         self._variable.trace("w", change)
 
-        
-    def _set_background_color(self, elements, key = AttributeNames.backgroundcolor):
+    def _set_background_color(self, elements, key=AttributeNames.backgroundcolor):
         value = self._attributes[key]["value"]
-        
-        self._menu.config(bg= value, activebackground=value)
+
+        self._menu.config(bg=value, activebackground=value)
         self._menu["menu"].config(bg=value, activebackground=value)
 
-    def _set_foreground_color(self, elements, key = AttributeNames.foregroundcolor):
+    def _set_foreground_color(self, elements, key=AttributeNames.foregroundcolor):
         value = self._attributes[key]["value"]
 
         self._menu.config(fg=value, activeforeground=value)
         self._menu["menu"].config(fg=value, activeforeground=value)
 
-    def _set_on_hover(self, elements): 
+    def _set_on_hover(self, elements):
         on_hover = self._attributes[AttributeNames.onhover]["value"]
 
-        on_hover_background_color = self._attributes[AttributeNames.onhover_background_color]["value"]
+        on_hover_background_color = self._attributes[
+            AttributeNames.onhover_background_color
+        ]["value"]
 
-        on_hover_foreground_color = self._attributes[AttributeNames.onhover_foreground_color]["value"]
+        on_hover_foreground_color = self._attributes[
+            AttributeNames.onhover_foreground_color
+        ]["value"]
 
         if on_hover == "true":
-            self._menu.config(activebackground=on_hover_background_color, activeforeground=on_hover_foreground_color)
-            self._menu["menu"].config(activebackground=on_hover_background_color, activeforeground=on_hover_foreground_color)
+            self._menu.config(
+                activebackground=on_hover_background_color,
+                activeforeground=on_hover_foreground_color,
+            )
+            self._menu["menu"].config(
+                activebackground=on_hover_background_color,
+                activeforeground=on_hover_foreground_color,
+            )
 
     def _set_selected(self, elements):
-        self._variable.set(self._attributes[AttributeNames.selected]['value'])
+        self._variable.set(self._attributes[AttributeNames.selected]["value"])
 
     def get_menu(self):
         return self._menu
 
     def _add_component_to_elements(self, elements):
-        self._menu.pack(expand=True, fill='both')
+        self._menu.pack(expand=True, fill="both")
 
         elements[str(self._id)] = self
-
-
-
-
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/dropdownmenu_item.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/dropdownmenu_item.py
@@ -5,6 +5,7 @@ import tkinter as tk
 
 from .root_cmp import *
 
+
 class DropdownmenuItem(RootCmp):
     """
     Is an item of a dropdown, e.g. for the dropdownmenu countries, germany would be a dropdownmenu-item.
@@ -16,38 +17,42 @@ class DropdownmenuItem(RootCmp):
             menu = parent.get_menu()
             return menu
         else:
-            error_string = "Parent of dropdown menu item " + self._id + " is not a dropdown menu."
+            error_string = (
+                "Parent of dropdown menu item " + self._id + " is not a dropdown menu."
+            )
             self._logger.error(error_string)
             raise Exception(error_string)
 
     @classmethod
-    def _get_attributes(cls, attributes = None):
+    def _get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.label] = {"value":"", "value_type":StringType}
+        attributes[AttributeNames.label] = {"value": "", "value_type": StringType}
 
         return attributes
 
     @classmethod
-    def _get_callbacks(cls, callbacks = None):
+    def _get_callbacks(cls, callbacks=None):
         if callbacks is None:
-            callbacks =  {}
+            callbacks = {}
 
-        callbacks[CallbackNames.click] = {"policy":None, "policy_type" : SymbolType}
+        callbacks[CallbackNames.click] = {"policy": None, "policy_type": SymbolType}
 
         return callbacks
 
-    def _define_click_event(self, elements, key = CallbackNames.click):
+    def _define_click_event(self, elements, key=CallbackNames.click):
         if self._callbacks[key]:
-            self._element['menu'].add_command(
+            self._element["menu"].add_command(
                 label=self._attributes[AttributeNames.label]["value"],
                 command=CallBackDefinition(
                     self._id,
                     self._parent,
-                    self._callbacks[key]['policy'],
+                    self._callbacks[key]["policy"],
                     elements,
-                    self._dropdownmenuitem_click))
+                    self._dropdownmenuitem_click,
+                ),
+            )
 
     def _dropdownmenuitem_click(self, id, parent_id, click_policy, elements):
         parent = elements[str(parent_id)]
@@ -57,20 +62,11 @@ class DropdownmenuItem(RootCmp):
             if click_policy is not None:
                 self._base_engine.post_with_policy(click_policy)
         else:
-            self._logger.warning("Could not set variable for dropdownmenu. Item id: %s, dropdown-menu-id: %s", str(id), str(parent_id))
+            self._logger.warning(
+                "Could not set variable for dropdownmenu. Item id: %s, dropdown-menu-id: %s",
+                str(id),
+                str(parent_id),
+            )
 
     def forget_children(self, elements):
         pass
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/label.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/label.py
@@ -5,10 +5,12 @@ import tkinter as tk
 
 from .root_cmp import *
 
+
 class Label(RootCmp, LayoutFollower, ConfigureSize, ConfigureFont):
     """
     The label can be used for positiion text. For available attributes see syntax definition. Implementation wise it is similarly implemented as the Dropdowmenu and Button - to make it work for layouting, the actual label is hidden and the element is actually a tkinter frame (therefore self._element is a frame, whereas self._label is the label).
     """
+
     def __init__(self, args, id, parent, attributes, callbacks, base_engine):
         super().__init__(args, id, parent, attributes, callbacks, base_engine)
         self._configure_font_element = None
@@ -23,88 +25,103 @@ class Label(RootCmp, LayoutFollower, ConfigureSize, ConfigureFont):
         return label_frame
 
     @classmethod
-    def _get_attributes(cls, attributes = None):
+    def _get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.label] = {"value":"", "value_type" : StringType}
-        attributes[AttributeNames.backgroundcolor] = {"value":"white", "value_type" : ColorType}
-        attributes[AttributeNames.foregroundcolor] = {"value":"black", "value_type" : ColorType}
+        attributes[AttributeNames.label] = {"value": "", "value_type": StringType}
+        attributes[AttributeNames.backgroundcolor] = {
+            "value": "white",
+            "value_type": ColorType,
+        }
+        attributes[AttributeNames.foregroundcolor] = {
+            "value": "black",
+            "value_type": ColorType,
+        }
         # Interactive-Attributes
-        attributes[AttributeNames.onhover] = {"value":False, "value_type" : BooleanType}
-        attributes[AttributeNames.onhover_background_color] = {"value":"white", "value_type" : ColorType}
-        attributes[AttributeNames.onhover_foreground_color] = {"value":"black", "value_type" : ColorType}
+        attributes[AttributeNames.onhover] = {"value": False, "value_type": BooleanType}
+        attributes[AttributeNames.onhover_background_color] = {
+            "value": "white",
+            "value_type": ColorType,
+        }
+        attributes[AttributeNames.onhover_foreground_color] = {
+            "value": "black",
+            "value_type": ColorType,
+        }
         return attributes
 
     @classmethod
-    def _get_callbacks(cls, callbacks = None):
+    def _get_callbacks(cls, callbacks=None):
         if callbacks is None:
             callbacks = {}
 
-        callbacks[CallbackNames.click] = {"policy":None, "policy_type": SymbolType}
+        callbacks[CallbackNames.click] = {"policy": None, "policy_type": SymbolType}
 
         return callbacks
 
-    #----------------------------------------------------------------------------------------------
-    #-----Standard-Attributes----
-    #----------------------------------------------------------------------------------------------
+    # ----------------------------------------------------------------------------------------------
+    # -----Standard-Attributes----
+    # ----------------------------------------------------------------------------------------------
 
-    def _set_label_text(self, elements, key = AttributeNames.label):
+    def _set_label_text(self, elements, key=AttributeNames.label):
         text = self._attributes[key]["value"]
-        self._label.configure(text = text)
+        self._label.configure(text=text)
 
-    def _set_background_color(self, elements, key = AttributeNames.backgroundcolor):
+    def _set_background_color(self, elements, key=AttributeNames.backgroundcolor):
         value = self._attributes[key]["value"]
-        self._label.configure(background = value)
+        self._label.configure(background=value)
 
-    def _set_foreground_color(self, elements, key = AttributeNames.foregroundcolor):
+    def _set_foreground_color(self, elements, key=AttributeNames.foregroundcolor):
         value = self._attributes[key]["value"]
-        self._label.configure(foreground = value)
+        self._label.configure(foreground=value)
 
-    #----------------------------------------------------------------------------------------------
-    #-----Special-Attributes----
-    #----------------------------------------------------------------------------------------------
+    # ----------------------------------------------------------------------------------------------
+    # -----Special-Attributes----
+    # ----------------------------------------------------------------------------------------------
 
-    def _set_on_hover(self, elements): 
+    def _set_on_hover(self, elements):
         on_hover = self._attributes[AttributeNames.onhover]["value"]
-        on_hover_background_color = self._attributes[AttributeNames.onhover_background_color]["value"]
+        on_hover_background_color = self._attributes[
+            AttributeNames.onhover_background_color
+        ]["value"]
 
-        on_hover_foreground_color = self._attributes[AttributeNames.onhover_foreground_color]["value"]
+        on_hover_foreground_color = self._attributes[
+            AttributeNames.onhover_foreground_color
+        ]["value"]
 
         if on_hover:
+
             def enter(event):
                 if on_hover_background_color != "":
-                    self._set_background_color(elements, key = AttributeNames.onhover_background_color)
+                    self._set_background_color(
+                        elements, key=AttributeNames.onhover_background_color
+                    )
                 if on_hover_foreground_color != "":
-                    self._set_foreground_color(elements, key = AttributeNames.onhover_foreground_color)
+                    self._set_foreground_color(
+                        elements, key=AttributeNames.onhover_foreground_color
+                    )
 
             def leave(event):
-                self._set_background_color(elements, key = AttributeNames.backgroundcolor)
-                self._set_foreground_color(elements, key= AttributeNames.foregroundcolor)
-    
-            self._label.bind('<Enter>', enter)
-            self._label.bind('<Leave>', leave)
+                self._set_background_color(elements, key=AttributeNames.backgroundcolor)
+                self._set_foreground_color(elements, key=AttributeNames.foregroundcolor)
 
- 
-    #----------------------------------------------------------------------------------------------
-    #-----Actions----
-    #----------------------------------------------------------------------------------------------
-       
+            self._label.bind("<Enter>", enter)
+            self._label.bind("<Leave>", leave)
+
+    # ----------------------------------------------------------------------------------------------
+    # -----Actions----
+    # ----------------------------------------------------------------------------------------------
+
     def _define_click_event(self, elements):
         key = CallbackNames.click
         if self._callbacks[key] and self._callbacks[key]["policy"]:
+
             def click_event(event):
                 self._base_engine.post_with_policy(self._callbacks[key]["policy"])
 
-            self._label.bind('<Button-1>', click_event)
+            self._label.bind("<Button-1>", click_event)
 
     def _add_component_to_elements(self, elements):
-        self._label.pack(expand=True, fill='both')
+        self._label.pack(expand=True, fill="both")
 
         elements[str(self._id)] = self
-
-
-
-
-
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/menu_bar.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/menu_bar.py
@@ -5,6 +5,7 @@ import tkinter as tk
 
 from .root_cmp import *
 
+
 class MenuBar(RootCmp):
     """
     The MenuBar is the class which resembles the menu-bar in tkinter. There must only be one in a clinguin ui file.
@@ -19,5 +20,3 @@ class MenuBar(RootCmp):
 
     def _add_component_to_elements(self, elements):
         elements[str(self._id)] = self
-
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/menu_bar_section.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/menu_bar_section.py
@@ -5,6 +5,7 @@ import tkinter as tk
 
 from .root_cmp import *
 
+
 class MenuBarSection(RootCmp):
     """
     The menu bar section is a section of a menu bar (e.g. in the menu \|main\|contact\|, where if one clicks on \|contact\| further the options \|location\|team\| appear, a menu-bar-section would be \|contact\|, whereas \|location\| and \|team\| would be menu-bar-section-items.
@@ -14,28 +15,27 @@ class MenuBarSection(RootCmp):
         menubar_element = elements[self._parent].get_element()
 
         menubar_section = tk.Menu(menubar_element)
-        
+
         return menubar_section
 
     @classmethod
-    def _get_attributes(cls, attributes = None):
+    def _get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.label] = {"value":"default_label", "value_type" : StringType}
+        attributes[AttributeNames.label] = {
+            "value": "default_label",
+            "value_type": StringType,
+        }
 
         return attributes
-
 
     def _set_sub_menu(self, elements):
         text = self._attributes[AttributeNames.label]["value"]
 
         menubar_element = elements[self._parent].get_element()
         menubar_element.add_cascade(label=text, menu=self._element)
-        
+
     def _add_component_to_elements(self, elements):
-       
+
         elements[str(self._id)] = self
-
-
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/menu_bar_section_item.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/menu_bar_section_item.py
@@ -4,14 +4,16 @@ Contains the menu bar section item class.
 from .root_cmp import *
 
 map = {
-    "Ctrl":"Control",
-    "Opt":"Option",
-    "Cmd":"Command",
-    "Control":"Control",
-    "Option":"Option",
-    "Command":"Command",
-    "Shift":"Shift"
+    "Ctrl": "Control",
+    "Opt": "Option",
+    "Cmd": "Command",
+    "Control": "Control",
+    "Option": "Option",
+    "Command": "Command",
+    "Shift": "Shift",
 }
+
+
 def accelerator_to_bind(a):
     args = a.split("+")
     formatted = []
@@ -20,7 +22,8 @@ def accelerator_to_bind(a):
             formatted.append(map[e])
         else:
             formatted.append(e.lower())
-    return "<"+"-".join(formatted)+">"
+    return "<" + "-".join(formatted) + ">"
+
 
 class MenuBarSectionItem(RootCmp):
     """
@@ -33,22 +36,27 @@ class MenuBarSectionItem(RootCmp):
         return menubar_section
 
     @classmethod
-    def _get_attributes(cls, attributes = None):
+    def _get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.label] = {"value":"standard_label", "value_type" : StringType}
-        attributes[AttributeNames.accelerator] = {"value":None, "value_type" : StringType}
+        attributes[AttributeNames.label] = {
+            "value": "standard_label",
+            "value_type": StringType,
+        }
+        attributes[AttributeNames.accelerator] = {
+            "value": None,
+            "value_type": StringType,
+        }
 
         return attributes
 
-
     @classmethod
-    def _get_callbacks(cls, callbacks = None):
+    def _get_callbacks(cls, callbacks=None):
         if callbacks is None:
             callbacks = {}
 
-        callbacks[CallbackNames.click] = {"policy":None, "policy_type" : SymbolType}
+        callbacks[CallbackNames.click] = {"policy": None, "policy_type": SymbolType}
 
         return callbacks
 
@@ -58,32 +66,27 @@ class MenuBarSectionItem(RootCmp):
         accelerator = self._attributes[AttributeNames.accelerator]["value"]
         if self._callbacks[key] and self._callbacks[key]["policy"]:
             cb = CallBackDefinition(
-                    self._id,
-                    self._parent,
-                    self._callbacks[key]["policy"],
-                    elements,
-                    self._menubar_item_click)
-            self._element.add_command(
-                label=text,
-                command=cb, accelerator=accelerator)
+                self._id,
+                self._parent,
+                self._callbacks[key]["policy"],
+                elements,
+                self._menubar_item_click,
+            )
+            self._element.add_command(label=text, command=cb, accelerator=accelerator)
             menu = elements[self._parent]
             window = elements[menu._parent]
             root = elements[window._parent]
             if accelerator:
                 root.get_element().bind(accelerator_to_bind(accelerator), cb)
         else:
-            self._element.add_command(
-                label=text)
-
+            self._element.add_command(label=text)
 
     def _menubar_item_click(self, id, parent, click_policy, elements):
         if click_policy is not None:
             self._base_engine.post_with_policy(click_policy)
- 
+
     def _add_component_to_elements(self, elements):
         elements[str(self._id)] = self
 
     def forget_children(self, elements):
         pass
-
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/message.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/message.py
@@ -2,29 +2,33 @@
 Contains the Message class.
 """
 import tkinter as tk
+
 # This import is used implicitly
 import tkinter.messagebox
 
 from .root_cmp import *
+
 
 class Message(RootCmp):
     """
     A message is a pop up, which has a type a title and a message.
     """
 
-
     def _init_element(self, elements):
         message = tk.Message(elements[str(self._parent)].get_element())
         return message
 
     @classmethod
-    def _get_attributes(cls, attributes = None):
+    def _get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.type] = {"value":PopupTypesType.INFO, "value_type" : PopupTypesType}
-        attributes[AttributeNames.title] = {"value":"", "value_type" : StringType}
-        attributes[AttributeNames.message] = {"value":"", "value_type" : StringType}
+        attributes[AttributeNames.type] = {
+            "value": PopupTypesType.INFO,
+            "value_type": PopupTypesType,
+        }
+        attributes[AttributeNames.title] = {"value": "", "value_type": StringType}
+        attributes[AttributeNames.message] = {"value": "", "value_type": StringType}
 
         return attributes
 
@@ -42,4 +46,3 @@ class Message(RootCmp):
             tk.messagebox.showerror(title=title, message=message)
         else:
             self._logger.warning("Cannot display popup-type %s", type)
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/root_cmp.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/root_cmp.py
@@ -5,6 +5,7 @@ import logging
 from clinguin.utils.attribute_types import *
 from ..tkinter_utils import *
 
+
 class RootCmp:
     """
     Every tkinter element must be a subtype of the RootCmp. It further features standard implementations of various methods, therefore one must just implement a handful of methods if one implements a new element, these are (see e.g. the button.py for a sample implementation):
@@ -15,7 +16,7 @@ class RootCmp:
     """
 
     def __init__(self, args, id, parent, attributes, callbacks, base_engine):
-        self._logger = logging.getLogger(args.log_args['name'])
+        self._logger = logging.getLogger(args.log_args["name"])
         self._id = id
         self._parent = parent
         self._json_attributes = attributes
@@ -29,37 +30,35 @@ class RootCmp:
     @classmethod
     def get_attributes(cls):
 
-        attributes = {} 
+        attributes = {}
         for base in cls.__bases__:
             if issubclass(base, ExtensionClass):
                 base.get_attributes(attributes)
-        
+
         return cls._get_attributes(attributes)
 
     @classmethod
-    def _get_attributes(cls, attributes = None):
+    def _get_attributes(cls, attributes=None):
         return {}
-
 
     @classmethod
     def get_callbacks(cls):
-        callbacks = {} 
+        callbacks = {}
         for base in cls.__bases__:
             if issubclass(base, ExtensionClass):
                 base.get_callbacks(callbacks)
-        
-        return cls._get_callbacks(callbacks)
-    
-    @classmethod
-    def _get_callbacks(cls, callbacks = None):
-        return {}
 
+        return cls._get_callbacks(callbacks)
+
+    @classmethod
+    def _get_callbacks(cls, callbacks=None):
+        return {}
 
     def get_element(self):
         return self._element
 
     def add_component(self, elements):
-        self._element = self._init_element(elements)        
+        self._element = self._init_element(elements)
 
         self._attributes = self.__class__.get_attributes()
         self._callbacks = self.__class__.get_callbacks()
@@ -71,45 +70,50 @@ class RootCmp:
         self._exec_actions(elements)
 
         self._add_component_to_elements(elements)
-    
+
     def _init_element(self, elements):
         return None
 
     def _fill_attributes(self):
         for attribute in self._json_attributes:
-            key = attribute['key']
-            value = attribute['value']
-            if key in self._attributes and 'value_type' in self._attributes[key]:
-                value_type = self._attributes[key]['value_type']
+            key = attribute["key"]
+            value = attribute["value"]
+            if key in self._attributes and "value_type" in self._attributes[key]:
+                value_type = self._attributes[key]["value_type"]
             else:
                 value_type = StringType
 
             if key in self._attributes and "value" in self._attributes[key]:
                 self._attributes[key]["value"] = value_type.parse(value, self._logger)
             else:
-                self._logger.warning('Undefined Command: ' + key + ' for element: ' + attribute['id'])
+                self._logger.warning(
+                    "Undefined Command: " + key + " for element: " + attribute["id"]
+                )
 
     def _fill_callbacks(self):
         for callback in self._json_callbacks:
-            key = callback['action']
-            value = callback['policy']
-            if key in self._callbacks and 'policy_type' in self._callbacks[key]:
-                value_type = self._callbacks[key]['policy_type']
+            key = callback["action"]
+            value = callback["policy"]
+            if key in self._callbacks and "policy_type" in self._callbacks[key]:
+                value_type = self._callbacks[key]["policy_type"]
             else:
                 value_type = SymbolType
 
             if key in self._callbacks and "policy" in self._callbacks[key]:
                 self._callbacks[key]["policy"] = value_type.parse(value, self._logger)
             else:
-                self._logger.warning('Undefined Command: %s, or policy item missing in command.', key)
+                self._logger.warning(
+                    "Undefined Command: %s, or policy item missing in command.", key
+                )
 
     def _get_methods(self, start_string):
 
         object_methods = []
         for method_name in dir(self):
-            if method_name.startswith(start_string) and callable(getattr(self, method_name)):
+            if method_name.startswith(start_string) and callable(
+                getattr(self, method_name)
+            ):
                 object_methods.append(getattr(self, method_name))
-
 
         return object_methods
 
@@ -126,12 +130,16 @@ class RootCmp:
 
     def _add_component_to_elements(self, elements):
         elements[str(self._id)] = self
-    
+
     def forget_children(self, elements):
         if str(self._parent) in elements:
             if hasattr(elements[self._parent], "get_child_org"):
                 parent_org = getattr(elements[self._parent], "get_child_org")()
-                if parent_org in (ChildLayoutType.FLEX, ChildLayoutType.RELSTATIC, ChildLayoutType.ABSSTATIC):
+                if parent_org in (
+                    ChildLayoutType.FLEX,
+                    ChildLayoutType.RELSTATIC,
+                    ChildLayoutType.ABSSTATIC,
+                ):
                     self._element.pack_forget()
                 elif parent_org == ChildLayoutType.GRID:
                     self._element.grid_forget()
@@ -141,5 +149,3 @@ class RootCmp:
                 self._element.forget()
         else:
             pass
-
-    

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/window.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_elements/window.py
@@ -5,6 +5,7 @@ import tkinter as tk
 
 from .root_cmp import *
 
+
 class Window(RootCmp, LayoutController):
     """
     The window class is the top-lvl. component, therefore it MUST be used in every clinguin application! For available attributes see syntax definition.
@@ -17,23 +18,26 @@ class Window(RootCmp, LayoutController):
         return window
 
     @classmethod
-    def _get_attributes(cls, attributes = None):
+    def _get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.backgroundcolor] = {"value":"white", "value_type" : ColorType}
-        attributes[AttributeNames.width] = {"value":0, "value_type" : IntegerType}
-        attributes[AttributeNames.height] = {"value":0, "value_type" : IntegerType}
-        attributes[AttributeNames.pos_x] = {"value":-1, "value_type": IntegerType}
-        attributes[AttributeNames.pos_y] = {"value":-1, "value_type": IntegerType}
-        attributes[AttributeNames.resizable_x] = {"value":1, "value_type" : IntegerType}
-        attributes[AttributeNames.resizable_y] = {"value":1, "value_type" : IntegerType}
+        attributes[AttributeNames.backgroundcolor] = {
+            "value": "white",
+            "value_type": ColorType,
+        }
+        attributes[AttributeNames.width] = {"value": 0, "value_type": IntegerType}
+        attributes[AttributeNames.height] = {"value": 0, "value_type": IntegerType}
+        attributes[AttributeNames.pos_x] = {"value": -1, "value_type": IntegerType}
+        attributes[AttributeNames.pos_y] = {"value": -1, "value_type": IntegerType}
+        attributes[AttributeNames.resizable_x] = {"value": 1, "value_type": IntegerType}
+        attributes[AttributeNames.resizable_y] = {"value": 1, "value_type": IntegerType}
 
         return attributes
 
-    def _set_background_color(self, elements, key = AttributeNames.backgroundcolor):
+    def _set_background_color(self, elements, key=AttributeNames.backgroundcolor):
         value = self._attributes[key]["value"]
-        self._element.configure(background = value)
+        self._element.configure(background=value)
 
     def _set_dimensions(self, elements):
         width = self._attributes[AttributeNames.width]["value"]
@@ -45,28 +49,34 @@ class Window(RootCmp, LayoutController):
         if height > 0 and width > 0:
             child_layout_value = self._attributes[AttributeNames.child_layout]["value"]
 
-            if child_layout_value in (ChildLayoutType.FLEX, ChildLayoutType.RELSTATIC, ChildLayoutType.ABSSTATIC):
+            if child_layout_value in (
+                ChildLayoutType.FLEX,
+                ChildLayoutType.RELSTATIC,
+                ChildLayoutType.ABSSTATIC,
+            ):
                 self._element.pack_propagate(0)
             elif child_layout_value == ChildLayoutType.GRID:
                 self._element.grid_propagate(0)
-        
+
             if pos_x < 0:
                 pos_x = int((int(self._element.winfo_screenwidth()) - int(width)) / 2)
             if pos_y < 0:
-                pos_y = int((int(self._element.winfo_screenheight()) - int(height))/2)
-            
-            self._element.geometry(str(width) + 'x' +
-                str(height) + '+' +
-                str(pos_x) + '+' +
-                str(pos_y))
+                pos_y = int((int(self._element.winfo_screenheight()) - int(height)) / 2)
+
+            self._element.geometry(
+                str(width) + "x" + str(height) + "+" + str(pos_x) + "+" + str(pos_y)
+            )
 
         elif (height > 0 and width <= 0) or (height <= 0 and width > 0):
-            self._logger.warning("For the tkinter window one must set both height and width to positive values (not just one).")
+            self._logger.warning(
+                "For the tkinter window one must set both height and width to positive values (not just one)."
+            )
 
     def _set_resizable(self, elements):
-        self._element.resizable(self._attributes[AttributeNames.resizable_x]['value'],self._attributes[AttributeNames.resizable_y]['value'])
-        
+        self._element.resizable(
+            self._attributes[AttributeNames.resizable_x]["value"],
+            self._attributes[AttributeNames.resizable_y]["value"],
+        )
+
     def _add_component_to_elements(self, elements):
         elements[str(self._id)] = self
-
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_frontend.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_frontend.py
@@ -20,8 +20,10 @@ class TkinterFrontend(AbstractFrontend):
         self.first = True
 
     @classmethod
-    def register_options(cls, parser):   
-        parser.description = "This GUI is based on the Python-Tkinter package and uses tkinter elements."
+    def register_options(cls, parser):
+        parser.description = (
+            "This GUI is based on the Python-Tkinter package and uses tkinter elements."
+        )
 
     @classmethod
     def available_syntax(cls, show_level):
@@ -38,72 +40,86 @@ class TkinterFrontend(AbstractFrontend):
                     elif key in AttributeNames.descriptions:
                         # General lesser priority
                         description = description + "      |- Description: "
-                        description = description + ": " + AttributeNames.descriptions[key]
+                        description = (
+                            description + ": " + AttributeNames.descriptions[key]
+                        )
                         description = description + "\n"
                     elif key in CallbackNames.descriptions:
                         description = description + "      |- Description: "
-                        description = description + ": " + CallbackNames.descriptions[key]
+                        description = (
+                            description + ": " + CallbackNames.descriptions[key]
+                        )
                         description = description + "\n"
 
                     if type_name in _dict[key]:
                         description = description + "      |- Possible-Values: "
-                        description = description + _dict[key][type_name].description() + "\n"
+                        description = (
+                            description + _dict[key][type_name].description() + "\n"
+                        )
 
             return description
 
-        description = "Here one finds the supported attributes and callbacks of the TkinterFrontend and further a definition of the syntax:\n" +\
-            "There are three syntax elements:\n\n" +\
-            "element(<ID>, <TYPE>, <PARENT>) : To define an element\n" +\
-            "attribute(<ID>, <KEY>, <VALUE>) : To define an attribute for an element (the ID is the ID of the corresponding element)\n" +\
-            "callback(<ID>, <ACTION>, <POLICY>) : To define a callback for an element (the ID is the ID of the corresponding element)\n\n" +\
-            "The following list shows for each <TYPE> the possible attributes and callbacks:\n" 
+        description = (
+            "Here one finds the supported attributes and callbacks of the TkinterFrontend and further a definition of the syntax:\n"
+            + "There are three syntax elements:\n\n"
+            + "element(<ID>, <TYPE>, <PARENT>) : To define an element\n"
+            + "attribute(<ID>, <KEY>, <VALUE>) : To define an attribute for an element (the ID is the ID of the corresponding element)\n"
+            + "callback(<ID>, <ACTION>, <POLICY>) : To define a callback for an element (the ID is the ID of the corresponding element)\n\n"
+            + "The following list shows for each <TYPE> the possible attributes and callbacks:\n"
+        )
 
         class_list = RootCmp.__subclasses__()
 
         description = description + "|--------------------------------\n"
         for c in class_list:
             description = description + "|- " + c.__name__ + "\n"
-            
+
             attributes = c.get_attributes()
             if len(attributes.keys()) > 0:
                 description = description + "  |- attributes\n"
                 description = append_dict(description, attributes, "value_type")
-            
+
             callbacks = c.get_callbacks()
-            if len(callbacks.keys()) > 0:               
+            if len(callbacks.keys()) > 0:
                 description = description + "  |- callbacks\n"
                 description = append_dict(description, callbacks, "policy_type")
             description = description + "|--------------------------------\n"
 
         return description
 
-
     def window(self, id, parent, attributes, callbacks):
 
         if self.first:
-            window = Window(self._args, id, parent, attributes, callbacks, self._base_engine)
+            window = Window(
+                self._args, id, parent, attributes, callbacks, self._base_engine
+            )
             window.add_component(self.elements)
         else:
             keys = list(self.elements.keys()).copy()
             for key in keys:
                 if str(key) == str(id):
                     continue
-                
+
                 if str(key) in self.elements:
                     self.elements[str(key)].forget_children(self.elements)
                     del self.elements[str(key)]
 
     def container(self, id, parent, attributes, callbacks):
-        container = Container(self._args, id, parent, attributes, callbacks, self._base_engine)
+        container = Container(
+            self._args, id, parent, attributes, callbacks, self._base_engine
+        )
         container.add_component(self.elements)
 
-
     def dropdown_menu(self, id, parent, attributes, callbacks):
-        menu = Dropdownmenu(self._args, id, parent, attributes, callbacks, self._base_engine)
+        menu = Dropdownmenu(
+            self._args, id, parent, attributes, callbacks, self._base_engine
+        )
         menu.add_component(self.elements)
 
     def dropdown_menu_item(self, id, parent, attributes, callbacks):
-        menu = DropdownmenuItem(self._args, id, parent, attributes, callbacks, self._base_engine)
+        menu = DropdownmenuItem(
+            self._args, id, parent, attributes, callbacks, self._base_engine
+        )
         menu.add_component(self.elements)
 
     def label(self, id, parent, attributes, callbacks):
@@ -111,27 +127,39 @@ class TkinterFrontend(AbstractFrontend):
         label.add_component(self.elements)
 
     def button(self, id, parent, attributes, callbacks):
-        button = Button(self._args, id, parent, attributes, callbacks, self._base_engine)
+        button = Button(
+            self._args, id, parent, attributes, callbacks, self._base_engine
+        )
         button.add_component(self.elements)
 
     def menu_bar(self, id, parent, attributes, callbacks):
-        menubar = MenuBar(self._args, id, parent, attributes, callbacks, self._base_engine)
+        menubar = MenuBar(
+            self._args, id, parent, attributes, callbacks, self._base_engine
+        )
         menubar.add_component(self.elements)
 
     def menu_bar_section(self, id, parent, attributes, callbacks):
-        menubar = MenuBarSection(self._args, id, parent, attributes, callbacks, self._base_engine)
+        menubar = MenuBarSection(
+            self._args, id, parent, attributes, callbacks, self._base_engine
+        )
         menubar.add_component(self.elements)
 
     def menu_bar_section_item(self, id, parent, attributes, callbacks):
-        menubar = MenuBarSectionItem(self._args, id, parent, attributes, callbacks, self._base_engine)
+        menubar = MenuBarSectionItem(
+            self._args, id, parent, attributes, callbacks, self._base_engine
+        )
         menubar.add_component(self.elements)
 
     def message(self, id, parent, attributes, callbacks):
-        message = Message(self._args, id, parent, attributes, callbacks, self._base_engine)
+        message = Message(
+            self._args, id, parent, attributes, callbacks, self._base_engine
+        )
         message.add_component(self.elements)
 
     def canvas(self, id, parent, attributes, callbacks):
-        canvas = Canvas(self._args, id, parent, attributes, callbacks, self._base_engine)
+        canvas = Canvas(
+            self._args, id, parent, attributes, callbacks, self._base_engine
+        )
         canvas.add_component(self.elements)
 
     def draw(self, id):

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/__init__.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/__init__.py
@@ -12,4 +12,14 @@ from .configure_size import ConfigureSize
 from .configure_border import ConfigureBorder
 from .configure_font import ConfigureFont
 
-__all__ = [AttributeNames.__name__, CallbackNames.__name__, CallBackDefinition.__name__, LayoutFollower.__name__, ExtensionClass.__name__, LayoutController.__name__, ConfigureSize.__name__, ConfigureBorder.__name__, ConfigureFont.__name__]
+__all__ = [
+    AttributeNames.__name__,
+    CallbackNames.__name__,
+    CallBackDefinition.__name__,
+    LayoutFollower.__name__,
+    ExtensionClass.__name__,
+    LayoutController.__name__,
+    ConfigureSize.__name__,
+    ConfigureBorder.__name__,
+    ConfigureFont.__name__,
+]

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/attribute_names.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/attribute_names.py
@@ -2,16 +2,16 @@
 Module that contains the AttributeNames class.
 """
 
+
 class AttributeNames:
     """
     This class contains all the names for all the attributes that are used for the Frontend and also contains some standard descriptions of the attributes.
     """
 
-    
     title = "title"
     message = "message"
     type = "type"
-    
+
     label = "label"
     backgroundcolor = "background_color"
     foregroundcolor = "foreground_color"
@@ -51,37 +51,36 @@ class AttributeNames:
 
     accelerator = "accelerator"
     descriptions = {
-        title : "With this attribute one can set the title of a pop-up.",
-        message : "With this attribute one can set the message of a pop-up.",
-        type : "With this attribute one can set the look and feel of the pop-up.",
-        label : "With this attribute one can set the label-text of the element.",
-        backgroundcolor : "With this attribute one can define the background-color of the element.",
-        foregroundcolor : "With this attribute one can set the foreground-color of the element.",
-        width : "With this attribute one can set the width in pixels of the element.",
-        height : "With this attribute one can set the height in pixels of the element.",
-        onhover : "With this attribute one can enable or disable on-hover features for the element.",
-        onhover_background_color : "With this attribute one can set the background color the element shall have, when on_hover is enabled.",
-        onhover_foreground_color : "With this attribute one can set the forground color the element shall have, when on_hover is eneabled.",
-        onhover_border_color : "With this attribute one can set the color the border of the element shall have, when on_hover is enabled.",
-        font_family : "With this attribute one can set the font-family of the element.",
-        font_size : "With this attribute one can set the font size in pixels.",
-        font_weight : "With this attribute one can set the font weight.",
-        resizable_x : "With this attribute one can define if the element shall be resizable in x direction.",
-        resizable_y : "With this attribute one can define if the element shall be resizable in y direction.",
-        child_layout : "With this attribute one can define the layout of the children, i.e. how they are positioned.",
-        grid_column : "With this attribute one can define in which column the element shall be positioned.",
-        grid_row : "With this attribute one can define in which row the element shall be positioned.",
-        grid_column_span : "With this attribute one can define, that the elements stretches over several columns.",
-        grid_row_span : "With this attribute one can define, that the elements stretches over several rows.",
-        pos_x : "With this attribute one sets the x-position of the element - it depends on the parent-child-layout how this is defined (either pixels, relative as a percentage, ...).",
-        pos_y : "With this attribute one sets the y-position of the element - it depends on the parent-child-layout how this is defined (either pixels, relative as a percentage, ...).",
-        border_width : "With this attribute one defines the width of the border in pixels.",
-        border_color : "With this attribute one may set the border color.",
-        selected : "With this attribute one may define the text that shall be displayed if something is selected.",
-        fit_children_size : "[DEPRECATED] - With this attribute one can define that the element fits the children.",
-        image : "Some backends define special values one can use, that e.g. a graph is shown (see corresponding backend description).",
-        image_path : "Include an image from a path.",
-        resize : "With this attribute one can define if an image shall be resized.",
-        accelerator: "The key binding for the menu option"
-        }
-
+        title: "With this attribute one can set the title of a pop-up.",
+        message: "With this attribute one can set the message of a pop-up.",
+        type: "With this attribute one can set the look and feel of the pop-up.",
+        label: "With this attribute one can set the label-text of the element.",
+        backgroundcolor: "With this attribute one can define the background-color of the element.",
+        foregroundcolor: "With this attribute one can set the foreground-color of the element.",
+        width: "With this attribute one can set the width in pixels of the element.",
+        height: "With this attribute one can set the height in pixels of the element.",
+        onhover: "With this attribute one can enable or disable on-hover features for the element.",
+        onhover_background_color: "With this attribute one can set the background color the element shall have, when on_hover is enabled.",
+        onhover_foreground_color: "With this attribute one can set the forground color the element shall have, when on_hover is eneabled.",
+        onhover_border_color: "With this attribute one can set the color the border of the element shall have, when on_hover is enabled.",
+        font_family: "With this attribute one can set the font-family of the element.",
+        font_size: "With this attribute one can set the font size in pixels.",
+        font_weight: "With this attribute one can set the font weight.",
+        resizable_x: "With this attribute one can define if the element shall be resizable in x direction.",
+        resizable_y: "With this attribute one can define if the element shall be resizable in y direction.",
+        child_layout: "With this attribute one can define the layout of the children, i.e. how they are positioned.",
+        grid_column: "With this attribute one can define in which column the element shall be positioned.",
+        grid_row: "With this attribute one can define in which row the element shall be positioned.",
+        grid_column_span: "With this attribute one can define, that the elements stretches over several columns.",
+        grid_row_span: "With this attribute one can define, that the elements stretches over several rows.",
+        pos_x: "With this attribute one sets the x-position of the element - it depends on the parent-child-layout how this is defined (either pixels, relative as a percentage, ...).",
+        pos_y: "With this attribute one sets the y-position of the element - it depends on the parent-child-layout how this is defined (either pixels, relative as a percentage, ...).",
+        border_width: "With this attribute one defines the width of the border in pixels.",
+        border_color: "With this attribute one may set the border color.",
+        selected: "With this attribute one may define the text that shall be displayed if something is selected.",
+        fit_children_size: "[DEPRECATED] - With this attribute one can define that the element fits the children.",
+        image: "Some backends define special values one can use, that e.g. a graph is shown (see corresponding backend description).",
+        image_path: "Include an image from a path.",
+        resize: "With this attribute one can define if an image shall be resized.",
+        accelerator: "The key binding for the menu option",
+    }

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/call_back_definition.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/call_back_definition.py
@@ -2,10 +2,12 @@
 This module contains the CallBackDefinition class.
 """
 
+
 class CallBackDefinition:
     """
     Some elements use this class to define their callbacks (others just do it locally, which is the preferred method).
     """
+
     def __init__(self, id, parent, click_policy, elements, callback):
         self._id = id
         self._parent = parent

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/callback_names.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/callback_names.py
@@ -2,15 +2,16 @@
 This module contains the CallbackNames class.
 """
 
+
 class CallbackNames:
     """
     This class contains all possible names for actions for callbacks and their descriptions.
     """
+
     click = "click"
     clear = "clear"
 
     descriptions = {
-        click : "The click action, is the action that is executed if one clicks with the left-mouse button on a element.",
-        clear : "The clearlick action, is the action that is executed when the empty option of a dropdown menu is selected."
+        click: "The click action, is the action that is executed if one clicks with the left-mouse button on a element.",
+        clear: "The clearlick action, is the action that is executed when the empty option of a dropdown menu is selected.",
     }
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/configure_border.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/configure_border.py
@@ -4,48 +4,47 @@ This module contains the ConfigureBorder class.
 
 from .extension_class import *
 
+
 class ConfigureBorder(ExtensionClass):
     """
     If a element shall have a border (e.g. container), it must be a subtype of this class.
     """
 
     @classmethod
-    def get_attributes(cls, attributes = None):
+    def get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.border_width] = {"value":0, "value_type" : IntegerType}
-        attributes[AttributeNames.border_color] = {"value":"black", "value_type" : ColorType}
+        attributes[AttributeNames.border_width] = {
+            "value": 0,
+            "value_type": IntegerType,
+        }
+        attributes[AttributeNames.border_color] = {
+            "value": "black",
+            "value_type": ColorType,
+        }
 
         return attributes
 
-    def _set_border_width(self, elements, key = AttributeNames.border_width):
+    def _set_border_width(self, elements, key=AttributeNames.border_width):
         value = self._attributes[key]["value"]
         if value > 0:
             # Not using borderwidth as one cannot set the color of the default border
-            self._element.configure(highlightthickness = int(value))
+            self._element.configure(highlightthickness=int(value))
         elif value == 0:
             # Zero is perfectly fine, but it shouldn't be configured then
             pass
         else:
-            self._logger.warning("For element " + self._id + " ,setBorderwidth for " + key + " is lesser than 0: " + str(value))
+            self._logger.warning(
+                "For element "
+                + self._id
+                + " ,setBorderwidth for "
+                + key
+                + " is lesser than 0: "
+                + str(value)
+            )
 
-    def _set_border_background_color(self, elements, key = AttributeNames.border_color):
+    def _set_border_background_color(self, elements, key=AttributeNames.border_color):
         # Not using borderwidth as one cannot set the color of the default border
         value = self._attributes[key]["value"]
-        self._element.configure(highlightbackground = value, highlightcolor = value)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        self._element.configure(highlightbackground=value, highlightcolor=value)

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/configure_font.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/configure_font.py
@@ -4,6 +4,7 @@ This module contains the ConfigureSize class.
 from .extension_class import *
 from tkinter import font
 
+
 class ConfigureFont(ExtensionClass):
     """
     If a element is a subtype of the configure-size class the size of the element can be adjusted.
@@ -13,19 +14,25 @@ class ConfigureFont(ExtensionClass):
         self._configure_font_element = None
 
     @classmethod
-    def get_attributes(cls, attributes = None):
+    def get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.font_family] = {"value":"", "value_type" : FontFamiliesType}
-        attributes[AttributeNames.font_size] = {"value":12, "value_type" : IntegerType}
-        attributes[AttributeNames.font_weight] = {"value":"normal", "value_type" : FontWeightType}
+        attributes[AttributeNames.font_family] = {
+            "value": "",
+            "value_type": FontFamiliesType,
+        }
+        attributes[AttributeNames.font_size] = {"value": 12, "value_type": IntegerType}
+        attributes[AttributeNames.font_weight] = {
+            "value": "normal",
+            "value_type": FontWeightType,
+        }
 
         return attributes
 
     def _set_font(self, elements):
-    
-        family = family=self._attributes[AttributeNames.font_family]["value"]
+
+        family = family = self._attributes[AttributeNames.font_family]["value"]
         size = int(self._attributes[AttributeNames.font_size]["value"])
         weight = self._attributes[AttributeNames.font_weight]["value"]
 
@@ -34,13 +41,12 @@ class ConfigureFont(ExtensionClass):
             kwargs["family"] = family
         if size > 0:
             kwargs["size"] = size
-        
+
         if weight in [FontWeightType.BOLD, FontWeightType.ITALIC_BOLD]:
             kwargs["weight"] = "bold"
         if weight in [FontWeightType.ITALIC, FontWeightType.ITALIC_BOLD]:
             kwargs["slant"] = "italic"
-        
+
         if family != "" or size != "" or weight != FontWeightType.NORMAL:
             afont = font.Font(**kwargs)
             self._configure_font_element.configure(font=afont)
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/configure_size.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/configure_size.py
@@ -3,18 +3,19 @@ This module contains the ConfigureSize class.
 """
 from .extension_class import *
 
+
 class ConfigureSize(ExtensionClass):
     """
     If a element is a subtype of the configure-size class the size of the element can be adjusted.
     """
 
     @classmethod
-    def get_attributes(cls, attributes = None):
+    def get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.height] = {"value":0, "value_type" : IntegerType}
-        attributes[AttributeNames.width] = {"value":0, "value_type" : IntegerType}
+        attributes[AttributeNames.height] = {"value": 0, "value_type": IntegerType}
+        attributes[AttributeNames.width] = {"value": 0, "value_type": IntegerType}
 
         return attributes
 
@@ -23,11 +24,17 @@ class ConfigureSize(ExtensionClass):
         width = self._attributes[AttributeNames.width]["value"]
 
         if height > 0 and width > 0:
-            # If height is set, 
+            # If height is set,
             if AttributeNames.child_layout in self._attributes:
-                child_layout_value = self._attributes[AttributeNames.child_layout]["value"]
+                child_layout_value = self._attributes[AttributeNames.child_layout][
+                    "value"
+                ]
 
-                if child_layout_value in (ChildLayoutType.FLEX, ChildLayoutType.RELSTATIC, ChildLayoutType.ABSSTATIC):
+                if child_layout_value in (
+                    ChildLayoutType.FLEX,
+                    ChildLayoutType.RELSTATIC,
+                    ChildLayoutType.ABSSTATIC,
+                ):
                     self._element.pack_propagate(0)
                 elif child_layout_value == ChildLayoutType.GRID:
                     self._element.grid_propagate(0)
@@ -35,14 +42,17 @@ class ConfigureSize(ExtensionClass):
                 self._element.pack_propagate(0)
 
         if height > 0:
-            self._element.configure(height = int(height))
+            self._element.configure(height=int(height))
 
         if width > 0:
-            self._element.configure(width = int(width))
-    
+            self._element.configure(width=int(width))
+
         if height < 0:
-            self._logger.warning("Height of " + self._id + " has illegal value (" + str(height) + ")")
+            self._logger.warning(
+                "Height of " + self._id + " has illegal value (" + str(height) + ")"
+            )
 
         if width < 0:
-            self._logger.warning("Width of " + self._id + " has illegal value (" + str(height) + ")")
-
+            self._logger.warning(
+                "Width of " + self._id + " has illegal value (" + str(height) + ")"
+            )

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/extension_class.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/extension_class.py
@@ -5,16 +5,16 @@ from clinguin.utils.attribute_types import *
 from .attribute_names import AttributeNames
 from .callback_names import CallbackNames
 
+
 class ExtensionClass:
     """
     If a class is a subtype of the ExtensionClass it resembles a set of attributes/callbacks that can be applied to elements.
     """
 
     @classmethod
-    def get_attributes(cls, attributes = None):
+    def get_attributes(cls, attributes=None):
         return {}
 
     @classmethod
-    def get_callbacks(cls, attributes = None):
+    def get_callbacks(cls, attributes=None):
         return {}
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/layout_controller.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/layout_controller.py
@@ -3,20 +3,24 @@ This module contains the LayoutController class.
 """
 from .extension_class import *
 
+
 class LayoutController(ExtensionClass):
     """
     If a element is a subtype of this class, then it can steer the layouting behavior of children.
     """
 
     @classmethod
-    def get_attributes(cls, attributes = None):
+    def get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
-        attributes[AttributeNames.child_layout] = {"value": ChildLayoutType.FLEX, "value_type" : ChildLayoutType}
+        attributes[AttributeNames.child_layout] = {
+            "value": ChildLayoutType.FLEX,
+            "value_type": ChildLayoutType,
+        }
 
         return attributes
- 
+
     def _set_child_org(self, elements):
         value = self._attributes[AttributeNames.child_layout]["value"]
         self._child_layout = value
@@ -26,5 +30,3 @@ class LayoutController(ExtensionClass):
 
     def get_fit_children_size(self):
         return self._fit_children_size
-
-

--- a/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/layout_follower.py
+++ b/clinguin/client/presentation/frontends/tkinter_frontend/tkinter_utils/layout_follower.py
@@ -6,6 +6,7 @@ from clinguin.utils import Logger
 
 from .extension_class import *
 
+
 class LayoutFollower(ExtensionClass):
     """
     If a element is a subtype of this class then one can be sure, that one can use it in layouts.
@@ -15,70 +16,92 @@ class LayoutFollower(ExtensionClass):
         self._logger = logging.getLogger(Logger.client_logger_name)
 
     @classmethod
-    def get_attributes(cls, attributes = None):
+    def get_attributes(cls, attributes=None):
         if attributes is None:
             attributes = {}
 
         # Layout-Control
-        attributes[AttributeNames.grid_column] = {"value":0, "value_type" : IntegerType}
-        attributes[AttributeNames.grid_row] = {"value":0, "value_type" : IntegerType}
-        attributes[AttributeNames.grid_column_span] = {"value":1, "value_type" : IntegerType}
-        attributes[AttributeNames.grid_row_span] = {"value":1, "value_type" : IntegerType}
+        attributes[AttributeNames.grid_column] = {"value": 0, "value_type": IntegerType}
+        attributes[AttributeNames.grid_row] = {"value": 0, "value_type": IntegerType}
+        attributes[AttributeNames.grid_column_span] = {
+            "value": 1,
+            "value_type": IntegerType,
+        }
+        attributes[AttributeNames.grid_row_span] = {
+            "value": 1,
+            "value_type": IntegerType,
+        }
 
-        attributes[AttributeNames.pos_x] = {"value":0, "value_type" : IntegerType}
-        attributes[AttributeNames.pos_y] = {"value":0, "value_type" : IntegerType}
+        attributes[AttributeNames.pos_x] = {"value": 0, "value_type": IntegerType}
+        attributes[AttributeNames.pos_y] = {"value": 0, "value_type": IntegerType}
 
         return attributes
-
 
     def _set_layout(self, elements):
         parent = elements[self._parent]
         if hasattr(parent, "get_child_org"):
             parent_org = getattr(parent, "get_child_org")()
         else:
-            self._logger.warning("Could not find necessary attribute childOrg() in id: %s", str(self._parent))
+            self._logger.warning(
+                "Could not find necessary attribute childOrg() in id: %s",
+                str(self._parent),
+            )
             return
 
         if parent_org == ChildLayoutType.FLEX:
-            self._element.pack(expand=True, fill='both')
+            self._element.pack(expand=True, fill="both")
 
         elif parent_org == ChildLayoutType.GRID:
-            grid_pos_column = self._attributes[AttributeNames.grid_column]['value']
-            grid_pos_row = self._attributes[AttributeNames.grid_row]['value']
+            grid_pos_column = self._attributes[AttributeNames.grid_column]["value"]
+            grid_pos_row = self._attributes[AttributeNames.grid_row]["value"]
 
-            grid_span_column = self._attributes[AttributeNames.grid_column_span]['value']
-            grid_span_row = self._attributes[AttributeNames.grid_row_span]['value']
+            grid_span_column = self._attributes[AttributeNames.grid_column_span][
+                "value"
+            ]
+            grid_span_row = self._attributes[AttributeNames.grid_row_span]["value"]
 
-            if int(grid_pos_column) >= 0 and int(grid_pos_row) >= 0 and int(grid_span_column) >= 1 and int(grid_span_row) >= 1:
+            if (
+                int(grid_pos_column) >= 0
+                and int(grid_pos_row) >= 0
+                and int(grid_span_column) >= 1
+                and int(grid_span_row) >= 1
+            ):
                 self._element.grid(
-                    column=grid_pos_column, 
+                    column=grid_pos_column,
                     row=grid_pos_row,
                     columnspan=int(grid_span_column),
-                    rowspan = int(grid_span_row))
+                    rowspan=int(grid_span_row),
+                )
             else:
-                self._logger.warning("Could not set grid-layout due to illegal values for element: %s", str(self._id)) 
+                self._logger.warning(
+                    "Could not set grid-layout due to illegal values for element: %s",
+                    str(self._id),
+                )
 
         elif parent_org in (ChildLayoutType.ABSSTATIC, ChildLayoutType.RELSTATIC):
-            self._element.pack(expand=True, fill='both')
+            self._element.pack(expand=True, fill="both")
 
             x = self._attributes[AttributeNames.pos_x]["value"]
             y = self._attributes[AttributeNames.pos_y]["value"]
 
             if int(x) >= 0 and int(y) >= 0:
                 if parent_org == ChildLayoutType.ABSSTATIC:
-                    self._element.place(
-                        x=int(x), 
-                        y=int(y))
+                    self._element.place(x=int(x), y=int(y))
                 elif parent_org == ChildLayoutType.RELSTATIC:
-                    self._element.place(
-                        relx=int(x)/100, 
-                        rely=int(y)/100)
+                    self._element.place(relx=int(x) / 100, rely=int(y) / 100)
                 else:
-                    error_string = "For element " + self._id + " ,either posx or posy are not non-negative-numbers. "
+                    error_string = (
+                        "For element "
+                        + self._id
+                        + " ,either posx or posy are not non-negative-numbers. "
+                    )
                     self._logger.error(error_string)
                     raise Exception(error_string)
             else:
-                self._logger.warning("For element %s invalid positioning supplied.", self._id)
+                self._logger.warning(
+                    "For element %s invalid positioning supplied.", self._id
+                )
         else:
-            self._logger.warning("For element %s no child layout was defined.", self._id)
-
+            self._logger.warning(
+                "For element %s no child layout was defined.", self._id
+            )

--- a/clinguin/client_helper.py
+++ b/clinguin/client_helper.py
@@ -4,11 +4,12 @@ Helper for the client-startup-process
 from clinguin.client import ClientBase
 from clinguin.utils import Logger
 
+
 def start(args):
     """
     Helper for the client-startup-process
     """
-    Logger.setup_logger(args.log_args, process = "client")
+    Logger.setup_logger(args.log_args, process="client")
 
     client = ClientBase(args)
     client.start_up()

--- a/clinguin/parse_input.py
+++ b/clinguin/parse_input.py
@@ -14,32 +14,33 @@ from .show_frontend_syntax_enum import ShowFrontendSyntaxEnum
 from .server import ClinguinBackend
 from .client import AbstractFrontend
 
-class ArgumentParser():
+
+class ArgumentParser:
     """
     ArgumentParser-Class, Responsible for parsing the command line attributes
     """
 
-    default_backend_exec_string = "from .server.application.backends import *"    
+    default_backend_exec_string = "from .server.application.backends import *"
     default_frontend_exec_string = "from .client.presentation.frontends import *"
 
-    default_backend = 'ClingoBackend'
-    default_frontend = 'TkinterFrontend'
+    default_backend = "ClingoBackend"
+    default_frontend = "TkinterFrontend"
 
     def __init__(self) -> None:
 
         self.frontend_name = None
         self.frontend = None
 
-
         self.titles = {
-            'client': self._client_title,
-            'server': self._server_title,
-            'client-server': self._client_server_title,
+            "client": self._client_title,
+            "server": self._server_title,
+            "client-server": self._client_server_title,
         }
         self.descriptions = {
-            'client': 'Start a client process that will render a UI.',
-            'server': 'Start server process making endpoints available for a client.',
-            'client-server': 'Start client and a server processes.'}
+            "client": "Start a client process that will render a UI.",
+            "server": "Start server process making endpoints available for a client.",
+            "client-server": "Start client and a server processes.",
+        }
         self.backend_name = None
         self.backend = None
         self._show_frontend_syntax = ShowFrontendSyntaxEnum.NONE
@@ -55,16 +56,20 @@ class ArgumentParser():
         else:
             process = sys.argv[0]
 
-        parser = argparse.ArgumentParser(description=self._clinguin_description(
-            process), add_help=True, formatter_class=argparse.RawTextHelpFormatter)
+        parser = argparse.ArgumentParser(
+            description=self._clinguin_description(process),
+            add_help=True,
+            formatter_class=argparse.RawTextHelpFormatter,
+        )
         subparsers = parser.add_subparsers(
             title="Process type",
-            description='The type of process to start: a client (UI) a server (Backend) or both',
-            dest='process')
+            description="The type of process to start: a client (UI) a server (Backend) or both",
+            dest="process",
+        )
         self._create_client_subparser(subparsers)
         self._create_server_subparser(subparsers)
         self._create_client_server_subparser(subparsers)
- 
+
         args = parser.parse_args()
 
         self._add_selected_backend(args)
@@ -77,41 +82,43 @@ class ArgumentParser():
 
     @property
     def _clinguin_title(self):
-        return '''
+        return """
               ___| (_)_ __   __ _ _   _(_)_ __
              / __| | | '_ \\ / _` | | | | | '_ \\
             | (__| | | | | | (_| | |_| | | | | |
              \\___|_|_|_| |_|\\__, |\\__,_|_|_| |_|
                             |___/
-            '''
+            """
 
     @property
     def _client_server_title(self):
-        return '''
+        return """
              _ | o  _  ._  _|_     _  _  ._     _  ._
             (_ | | (/_ | |  |_    _> (/_ |  \\/ (/_ |
 
-            '''
+            """
 
     @property
     def _client_title(self):
-        return '''
+        return """
                        _ | o  _  ._  _|_
                       (_ | | (/_ | |  |_
 
-            '''
+            """
 
     @property
     def _server_title(self):
-        return '''
+        return """
                        _  _  ._     _  ._
                       _> (/_ |  \\/ (/_ |
 
-            '''
+            """
 
     def _clinguin_description(self, process):
-        description = 'Clinguin is a GUI language extension for a logic program that uses Clingo.'
-        if process not in ['server', 'client', 'client-server']:
+        description = (
+            "Clinguin is a GUI language extension for a logic program that uses Clingo."
+        )
+        if process not in ["server", "client", "client-server"]:
             ascci = f"{self._clinguin_title}{description}"
             return f"{inspect.cleandoc(ascci)}\n\n{description}"
         else:
@@ -123,11 +130,11 @@ class ArgumentParser():
         if os.path.isfile(path):
             sys.path.append(os.path.dirname(path))
             self._import_files_from_path_array([path])
-        else: 
+        else:
             sys.path.append(path)
             self._recursive_import(path, "", "")
 
-    def _import_files_from_path_array(self,file_paths, module = ""):
+    def _import_files_from_path_array(self, file_paths, module=""):
         for file_path in file_paths:
             base = os.path.basename(file_path)
             file_name = os.path.splitext(base)[0]
@@ -135,19 +142,19 @@ class ArgumentParser():
             if ending == ".py":
                 if module != "":
                     try:
-                        importlib.import_module(module + "." + file_name)       
+                        importlib.import_module(module + "." + file_name)
                     except Exception:
                         print("Could not import module: " + module + "." + file_name)
                         print("<<<BEGIN-STACK-TRACE>>>")
                         traceback.print_exc()
                         print("<<<END-STACK-TRACE>>>")
-                else: 
-                    importlib.import_module(file_name)       
+                else:
+                    importlib.import_module(file_name)
 
     def _recursive_import(self, full_path, rec_path, module):
         folder_paths = []
         file_paths = []
-        
+
         try:
             for entity in os.scandir(os.path.join(full_path, rec_path)):
                 if entity.is_dir():
@@ -158,8 +165,12 @@ class ArgumentParser():
             print("<<<BEGIN-STACK-TRACE>>>")
             traceback.print_exc()
             print("<<<END-STACK-TRACE>>>")
-            raise Exception("Could not find path for importing libraries: " + os.path.join(full_path, rec_path) + ". Therefore program is terminating now (full stacktrace is printed below).")
-            
+            raise Exception(
+                "Could not find path for importing libraries: "
+                + os.path.join(full_path, rec_path)
+                + ". Therefore program is terminating now (full stacktrace is printed below)."
+            )
+
         self._import_files_from_path_array(file_paths)
 
         for folder_path in folder_paths:
@@ -178,7 +189,7 @@ class ArgumentParser():
         self._add_default_arguments_to_client_parser(custom_imports_parser)
 
         args, _ = custom_imports_parser.parse_known_args()
-    
+
         self.frontend_name = args.frontend
         self.backend_name = args.backend
         if args.custom_classes:
@@ -187,59 +198,93 @@ class ArgumentParser():
         exec(ArgumentParser.default_backend_exec_string)
         exec(ArgumentParser.default_frontend_exec_string)
 
-
         if args.frontend_syntax and not args.frontend_syntax_full:
             self._show_frontend_syntax = ShowFrontendSyntaxEnum.SHOW
         elif args.frontend_syntax_full:
             self._show_frontend_syntax = ShowFrontendSyntaxEnum.FULL
-        
 
     def _create_client_subparser(self, subparsers):
         parser_client = subparsers.add_parser(
-            'client',
-            help=self.descriptions['client'],
-            description=self._clinguin_description('client'),
+            "client",
+            help=self.descriptions["client"],
+            description=self._clinguin_description("client"),
             add_help=True,
-            formatter_class=argparse.RawTextHelpFormatter)
+            formatter_class=argparse.RawTextHelpFormatter,
+        )
 
-        self._add_log_arguments(parser_client, abbrevation='C', logger_name = 'clinguin_client')       
+        self._add_log_arguments(
+            parser_client, abbrevation="C", logger_name="clinguin_client"
+        )
 
         self._add_default_arguments_to_client_parser(parser_client)
-        self.frontend = self._select_subclass_and_add_custom_arguments(parser_client, AbstractFrontend, self.frontend_name, ArgumentParser.default_frontend)
+        self.frontend = self._select_subclass_and_add_custom_arguments(
+            parser_client,
+            AbstractFrontend,
+            self.frontend_name,
+            ArgumentParser.default_frontend,
+        )
 
         return parser_client
 
     def _create_server_subparser(self, subparsers):
         parser_server = subparsers.add_parser(
-            'server',
-            help=self.descriptions['server'],
-            description=self._clinguin_description('server'),
+            "server",
+            help=self.descriptions["server"],
+            description=self._clinguin_description("server"),
             add_help=True,
-            formatter_class=argparse.RawTextHelpFormatter)
+            formatter_class=argparse.RawTextHelpFormatter,
+        )
 
-        self._add_log_arguments(parser_server, abbrevation='S', logger_name = 'clinguin_server')       
+        self._add_log_arguments(
+            parser_server, abbrevation="S", logger_name="clinguin_server"
+        )
         self._add_default_arguments_to_backend_parser(parser_server)
-        self.backend = self._select_subclass_and_add_custom_arguments(parser_server, ClinguinBackend, self.backend_name, ArgumentParser.default_backend)
+        self.backend = self._select_subclass_and_add_custom_arguments(
+            parser_server,
+            ClinguinBackend,
+            self.backend_name,
+            ArgumentParser.default_backend,
+        )
 
         return parser_server
 
     def _create_client_server_subparser(self, subparsers):
-        parser_server_client = subparsers.add_parser('client-server',
-                                                     help=self.descriptions['client-server'],
-                                                     description=self._clinguin_description(
-                                                         'client-server'),
-                                                     add_help=True,
-                                                     formatter_class=argparse.RawTextHelpFormatter)
+        parser_server_client = subparsers.add_parser(
+            "client-server",
+            help=self.descriptions["client-server"],
+            description=self._clinguin_description("client-server"),
+            add_help=True,
+            formatter_class=argparse.RawTextHelpFormatter,
+        )
 
-
-        self._add_log_arguments(parser_server_client, abbrevation='C', logger_name = 'clinguin_client', display_name= 'client-')       
-        self._add_log_arguments(parser_server_client, abbrevation='S', logger_name = 'clinguin_server', display_name ='server-')       
+        self._add_log_arguments(
+            parser_server_client,
+            abbrevation="C",
+            logger_name="clinguin_client",
+            display_name="client-",
+        )
+        self._add_log_arguments(
+            parser_server_client,
+            abbrevation="S",
+            logger_name="clinguin_server",
+            display_name="server-",
+        )
 
         self._add_default_arguments_to_client_parser(parser_server_client)
-        self.frontend = self._select_subclass_and_add_custom_arguments(parser_server_client, AbstractFrontend, self.frontend_name, ArgumentParser.default_frontend)
+        self.frontend = self._select_subclass_and_add_custom_arguments(
+            parser_server_client,
+            AbstractFrontend,
+            self.frontend_name,
+            ArgumentParser.default_frontend,
+        )
 
         self._add_default_arguments_to_backend_parser(parser_server_client)
-        self.backend = self._select_subclass_and_add_custom_arguments(parser_server_client, ClinguinBackend, self.backend_name, ArgumentParser.default_backend)
+        self.backend = self._select_subclass_and_add_custom_arguments(
+            parser_server_client,
+            ClinguinBackend,
+            self.backend_name,
+            ArgumentParser.default_backend,
+        )
 
         return parser_server_client
 
@@ -247,75 +292,92 @@ class ArgumentParser():
         sub_classes = self._get_sub_classes(ClinguinBackend)
         sub_class_as_options = "|".join([s.__name__ for s in sub_classes])
         sub_classes_str = "=>  Available options: {" + sub_class_as_options + "}"
-        parser.add_argument('--backend', type=str,
-                            help=textwrap.dedent(f'''\
+        parser.add_argument(
+            "--backend",
+            type=str,
+            help=textwrap.dedent(
+                f"""\
                 Optionally specify which backend to use using the class name.
                 {sub_classes_str}
-                '''),
-                            metavar='')
+                """
+            ),
+            metavar="",
+        )
         parser.add_argument(
-            '--custom-classes',
-            type=str,
-            help='Path to custom classes.',
-            metavar='')
+            "--custom-classes", type=str, help="Path to custom classes.", metavar=""
+        )
 
     def _add_default_arguments_to_client_parser(self, parser):
         sub_classes = self._get_sub_classes(AbstractFrontend)
         sub_class_as_options = "|".join([s.__name__ for s in sub_classes])
         sub_classes_str = "=>  Available options: {" + sub_class_as_options + "}"
-        parser.add_argument('--frontend', type=str,
-                            help=textwrap.dedent(f'''\
+        parser.add_argument(
+            "--frontend",
+            type=str,
+            help=textwrap.dedent(
+                f"""\
                 Optionally specify which frontend to use using the class name.
                 {sub_classes_str}
-                '''),
-                            metavar='')
-        parser.add_argument('--frontend-syntax', 
-                action='store_true',
-                help='Show available commands for the GUI.')
-        parser.add_argument('--frontend-syntax-full', 
-                action='store_true',
-                help='Show available commands for the GUI and shows available value-types.')
-        
+                """
+            ),
+            metavar="",
+        )
+        parser.add_argument(
+            "--frontend-syntax",
+            action="store_true",
+            help="Show available commands for the GUI.",
+        )
+        parser.add_argument(
+            "--frontend-syntax-full",
+            action="store_true",
+            help="Show available commands for the GUI and shows available value-types.",
+        )
 
-    def _add_log_arguments(self, parser, abbrevation='', logger_name = '', display_name=''):
+    def _add_log_arguments(
+        self, parser, abbrevation="", logger_name="", display_name=""
+    ):
 
-        group = parser.add_argument_group(display_name + 'logger')
-        group.add_argument('--' + display_name + 'log-disable-shell',
-                                   action='store_true',
-                                   help='Disable shell logging')
-        group.add_argument('--' + display_name + 'log-enable-file',
-                                   action='store_true',
-                                   help='Disable file logging')
-        group.add_argument('--' + display_name + 'logger-name',
-                                   type=str,
-                                   help='Set logger name',
-                                   metavar='',
-                                   default=logger_name)
+        group = parser.add_argument_group(display_name + "logger")
         group.add_argument(
-            '--' + display_name + 'log-level',
-            type=str,
-            help='Log level',
-            metavar='',
-            choices=[
-                'DEBUG',
-                'INFO',
-                'ERROR',
-                'WARNING'],
-            default='INFO')
+            "--" + display_name + "log-disable-shell",
+            action="store_true",
+            help="Disable shell logging",
+        )
         group.add_argument(
-            '--' + display_name + 'log-format-shell',
-            type=str,
-            help='Log format shell',
-            metavar='',
-            default='['+str(abbrevation)+'] %(levelname)s: %(message)s')
+            "--" + display_name + "log-enable-file",
+            action="store_true",
+            help="Disable file logging",
+        )
         group.add_argument(
-            '--' + display_name + 'log-format-file',
+            "--" + display_name + "logger-name",
             type=str,
-            help='Log format file',
-            metavar='',
-            default='%(levelname)s: %(message)s')
+            help="Set logger name",
+            metavar="",
+            default=logger_name,
+        )
+        group.add_argument(
+            "--" + display_name + "log-level",
+            type=str,
+            help="Log level",
+            metavar="",
+            choices=["DEBUG", "INFO", "ERROR", "WARNING"],
+            default="INFO",
+        )
+        group.add_argument(
+            "--" + display_name + "log-format-shell",
+            type=str,
+            help="Log format shell",
+            metavar="",
+            default="[" + str(abbrevation) + "] %(levelname)s: %(message)s",
+        )
+        group.add_argument(
+            "--" + display_name + "log-format-file",
+            type=str,
+            help="Log format file",
+            metavar="",
+            default="%(levelname)s: %(message)s",
+        )
 
-  
     def _get_sub_classes(self, cur_class):
         sub_classes = cur_class.__subclasses__()
         recursive = []
@@ -324,26 +386,33 @@ class ArgumentParser():
 
         return sub_classes + recursive
 
-
-    def _select_subclass_and_add_custom_arguments(self, parser, parent, class_name, default_class):
+    def _select_subclass_and_add_custom_arguments(
+        self, parser, parent, class_name, default_class
+    ):
         sub_classes = self._get_sub_classes(parent)
-        
+
         selected_class = None
 
         for sub_class in sub_classes:
             full_class_name = sub_class.__name__
             selected_by_default = not class_name and full_class_name == default_class
-            selected =  full_class_name == class_name
+            selected = full_class_name == class_name
             if selected_by_default or selected:
                 group = parser.add_argument_group(full_class_name)
                 sub_class.register_options(group)
-        
-                should_show_frontend_syntax = self._show_frontend_syntax == ShowFrontendSyntaxEnum.SHOW or self._show_frontend_syntax  == ShowFrontendSyntaxEnum.FULL
-                if should_show_frontend_syntax and hasattr(sub_class, 'available_syntax'):
+
+                should_show_frontend_syntax = (
+                    self._show_frontend_syntax == ShowFrontendSyntaxEnum.SHOW
+                    or self._show_frontend_syntax == ShowFrontendSyntaxEnum.FULL
+                )
+                if should_show_frontend_syntax and hasattr(
+                    sub_class, "available_syntax"
+                ):
                     print(sub_class.available_syntax(self._show_frontend_syntax))
                     sys.exit()
 
                 selected_class = sub_class
         return selected_class
+
 
 # W0703,R0201,W0707,W0122

--- a/clinguin/server/__init__.py
+++ b/clinguin/server/__init__.py
@@ -6,6 +6,9 @@ from .application.standard_json_encoder import StandardJsonEncoder
 from .application.clinguin_backend import ClinguinBackend
 from .data.clinguin_model import ClinguinModel
 
-__all__ = [Endpoints.__name__, StandardJsonEncoder.__name__, ClinguinBackend.__name__, ClinguinModel.__name__]
-
-
+__all__ = [
+    Endpoints.__name__,
+    StandardJsonEncoder.__name__,
+    ClinguinBackend.__name__,
+    ClinguinModel.__name__,
+]

--- a/clinguin/server/application/attribute.py
+++ b/clinguin/server/application/attribute.py
@@ -8,6 +8,7 @@ class AttributeDto:
     """
     Objects of this class represent the attributes in the json convertible hierarchy.
     """
+
     def __init__(self, id, key, value):
         self.id = str(id)
         self.key = str(key)

--- a/clinguin/server/application/backends/__init__.py
+++ b/clinguin/server/application/backends/__init__.py
@@ -6,9 +6,9 @@ from clinguin.server.application.backends.clingraph_backend import ClingraphBack
 from clinguin.server.application.backends.temporal_backend import TemporalBackend
 from clinguin.server.application.backends.explanation_backend import ExplanationBackend
 
-__all__ = [ClingoBackend.__name__,
-            ClingraphBackend.__name__,
-            TemporalBackend.__name__,
-            ExplanationBackend.__name__
-            ]
-
+__all__ = [
+    ClingoBackend.__name__,
+    ClingraphBackend.__name__,
+    TemporalBackend.__name__,
+    ExplanationBackend.__name__,
+]

--- a/clinguin/server/application/backends/clingo_backend.py
+++ b/clinguin/server/application/backends/clingo_backend.py
@@ -5,6 +5,7 @@ import sys
 
 from clingo import Control, parse_term
 from clingo.script import enable_python
+
 # Self defined
 from clinguin.utils.errors import NoModelError
 from clinguin.server import StandardJsonEncoder
@@ -14,6 +15,7 @@ from clinguin.server.application.backends.standard_utils.brave_cautious_helper i
 
 
 enable_python()
+
 
 class ClingoBackend(ClinguinBackend):
     """
@@ -25,22 +27,21 @@ class ClingoBackend(ClinguinBackend):
 
         self._source_files = args.source_files
         self._ui_files = args.ui_files
-        
+
         # For browising
-        self._handler=None
-        self._iterator=None
+        self._handler = None
+        self._iterator = None
 
         # To make static linters happy
         self._assumptions = None
         self._atoms = None
         self._ctl = None
-        
+
         self._restart()
-        
+
         # I think we should remove this and only have one ClinguinModel
         self._modelClass = ClinguinModel
-        self._model=None
-
+        self._model = None
 
     # ---------------------------------------------
     # Required methods
@@ -52,14 +53,16 @@ class ClingoBackend(ClinguinBackend):
         """
         if not self._model:
             self._update_model()
-        json_structure =  StandardJsonEncoder.encode(self._model)
+        json_structure = StandardJsonEncoder.encode(self._model)
         return json_structure
 
     @classmethod
     def register_options(cls, parser):
-        parser.add_argument('--source-files', nargs='+', help='Files',metavar='')
-        parser.add_argument('--ui-files', nargs='+', help='Files for the element generation',metavar='')
-    
+        parser.add_argument("--source-files", nargs="+", help="Files", metavar="")
+        parser.add_argument(
+            "--ui-files", nargs="+", help="Files for the element generation", metavar=""
+        )
+
     # ---------------------------------------------
     # Private methods
     # ---------------------------------------------
@@ -67,28 +70,29 @@ class ClingoBackend(ClinguinBackend):
     def _restart(self):
         self._end_browsing()
         self._assumptions = set()
-        self._externals = {"true":set(),"false":set(),"released":set()}
+        self._externals = {"true": set(), "false": set(), "released": set()}
         self._atoms = set()
         self._init_ctl()
         self._ground()
 
     def _init_ctl(self):
-        self._ctl = Control(['0'])
+        self._ctl = Control(["0"])
         for f in self._source_files:
             try:
                 self._ctl.load(str(f))
             except Exception as e:
                 self._logger.critical(str(e))
-                self._logger.critical("Failed to load modules (there is likely a syntax error in your logic program), now exiting - see previous stack trace for more information.")
+                self._logger.critical(
+                    "Failed to load modules (there is likely a syntax error in your logic program), now exiting - see previous stack trace for more information."
+                )
                 sys.exit()
-        
+
         for atom in self._atoms:
-            self._ctl.add("base",[],str(atom) + ".")
-    
+            self._ctl.add("base", [], str(atom) + ".")
+
     def _ground(self):
         self._ctl.ground([("base", [])])
 
-    
     def _end_browsing(self):
         if self._handler:
             self._handler.cancel()
@@ -98,11 +102,10 @@ class ClingoBackend(ClinguinBackend):
     def _update_model(self):
         try:
             self._model = ClinguinModel.from_ui_file(
-                self._ctl,
-                self._ui_files, 
-                self._assumptions)
+                self._ctl, self._ui_files, self._assumptions
+            )
         except NoModelError:
-            self._model.add_message("Error","This operation can't be performed")
+            self._model.add_message("Error", "This operation can't be performed")
 
     # ---------------------------------------------
     # Policies
@@ -142,7 +145,7 @@ class ClingoBackend(ClinguinBackend):
             self._end_browsing()
             self._update_model()
         return self.get()
-   
+
     def remove_assumption_signature(self, predicate):
         """
         Policy: removes predicates with the predicate name of predicate and the given arity
@@ -151,20 +154,19 @@ class ClingoBackend(ClinguinBackend):
         arity = len(predicate_symbol.arguments)
         to_remove = []
         for s in self._assumptions:
-            if s.match(predicate_symbol.name,arity):
-                for i,a in enumerate(predicate_symbol.arguments):
-                    if str(a)!='any' and s.arguments[i] != a:
+            if s.match(predicate_symbol.name, arity):
+                for i, a in enumerate(predicate_symbol.arguments):
+                    if str(a) != "any" and s.arguments[i] != a:
                         break
                 else:
                     to_remove.append(s)
                     continue
         for s in to_remove:
             self._assumptions.remove(s)
-        if len(to_remove)>0:
+        if len(to_remove) > 0:
             self._end_browsing()
             self._update_model()
         return self.get()
-
 
     def clear_atoms(self):
         """
@@ -192,7 +194,7 @@ class ClingoBackend(ClinguinBackend):
             self._update_model()
         return self.get()
 
-    def remove_atom(self,predicate):
+    def remove_atom(self, predicate):
         """
         Policy: Removes an assumption and basically resets the rest of the application (reground) - finally it returns the udpated Json structure.
         """
@@ -218,47 +220,48 @@ class ClingoBackend(ClinguinBackend):
 
             if symbol in self._externals["true"]:
                 self._externals["true"].remove(symbol)
-    
+
             if symbol in self._externals["false"]:
                 self._externals["false"].remove(symbol)
 
         elif name == "true":
-            self._ctl.assign_external(parse_term(predicate),True)
+            self._ctl.assign_external(parse_term(predicate), True)
             self._externals["true"].add(symbol)
 
             if symbol in self._externals["false"]:
                 self._externals["false"].remove(symbol)
 
         elif name == "false":
-            self._ctl.assign_external(parse_term(predicate),True)
+            self._ctl.assign_external(parse_term(predicate), True)
             self._externals["false"].add(symbol)
 
             if symbol in self._externals["true"]:
                 self._externals["true"].remove(symbol)
 
         else:
-            raise ValueError(f"Invalid external value {name}. Must be true, false or relase")
+            raise ValueError(
+                f"Invalid external value {name}. Must be true, false or relase"
+            )
 
         self._update_model()
         return self.get()
 
-
-    def next_solution(self, opt_mode='ignore'):
+    def next_solution(self, opt_mode="ignore"):
         """
-        Policy: Obtains the next solution 
+        Policy: Obtains the next solution
         Arguments:
             opt_mode: The clingo optimization mode, bu default is 'ignore', to browse only optimal models use 'optN'
         """
         if self._ctl.configuration.solve.opt_mode != opt_mode:
             self._logger.debug("Ended browsing since opt mode changed")
             self._end_browsing()
-        optimizing = opt_mode in ['optN','opt']
+        optimizing = opt_mode in ["optN", "opt"]
         if not self._iterator:
-            self._ctl.configuration.solve.enum_mode = 'auto'
+            self._ctl.configuration.solve.enum_mode = "auto"
             self._ctl.configuration.solve.opt_mode = opt_mode
             self._handler = self._ctl.solve(
-                assumptions=[(a,True) for a in self._assumptions],
-                yield_=True)
+                assumptions=[(a, True) for a in self._assumptions], yield_=True
+            )
             self._iterator = iter(self._handler)
         try:
             model = next(self._iterator)
@@ -270,6 +273,6 @@ class ClingoBackend(ClinguinBackend):
             self._logger.info("No more solutions")
             self._end_browsing()
             self._update_model()
-            self._model.add_message("Browsing Information","No more solutions")
+            self._model.add_message("Browsing Information", "No more solutions")
 
         return self.get()

--- a/clinguin/server/application/backends/clingraph_backend.py
+++ b/clinguin/server/application/backends/clingraph_backend.py
@@ -23,6 +23,7 @@ from clinguin.server import StandardJsonEncoder
 from clinguin.server.application.backends.clingo_backend import ClingoBackend
 from clinguin.utils import NoModelError
 
+
 class ClingraphBackend(ClingoBackend):
     """
     Extends ClingoBackend. With this Backend it is possible to create Clingraph-graphs by Clinguin. This can be done by both saving them to a file and by sending them to the client.
@@ -41,11 +42,11 @@ class ClingraphBackend(ClingoBackend):
         self._engine = args.engine
         self._disable_saved_to_file = args.disable_saved_to_file
 
-        self._intermediate_format = 'png'
-        self._encoding = 'utf-8'
-        self._attribute_image_key = 'image'
-        self._attribute_image_value = 'clingraph'
-        self._attribute_image_value_seperator = '__'
+        self._intermediate_format = "png"
+        self._encoding = "utf-8"
+        self._attribute_image_key = "image"
+        self._attribute_image_value = "clingraph"
+        self._attribute_image_value_seperator = "__"
 
         self._filled_model = None
 
@@ -55,18 +56,22 @@ class ClingraphBackend(ClingoBackend):
 
     def _update_model(self):
         try:
-            prg = ClinguinModel.get_cautious_brave(self._ctl,self._assumptions)
-            self._model = ClinguinModel.from_ui_file_and_program(self._ctl,self._ui_files,prg,self._assumptions)
+            prg = ClinguinModel.get_cautious_brave(self._ctl, self._assumptions)
+            self._model = ClinguinModel.from_ui_file_and_program(
+                self._ctl, self._ui_files, prg, self._assumptions
+            )
 
             graphs = self._compute_clingraph_graphs(prg)
 
             if not self._disable_saved_to_file:
                 self._save_clingraph_graphs_to_file(graphs)
 
-            self._filled_model = self._get_mode_filled_with_base_64_images_from_graphs(graphs)
+            self._filled_model = self._get_mode_filled_with_base_64_images_from_graphs(
+                graphs
+            )
 
         except NoModelError:
-            self._model.add_message("Error","This operation can't be performed")
+            self._model.add_message("Error", "This operation can't be performed")
 
     def get(self):
         """
@@ -74,183 +79,242 @@ class ClingraphBackend(ClingoBackend):
         """
         if not self._filled_model:
             self._update_model()
-            
+
         json_structure = StandardJsonEncoder.encode(self._filled_model)
         return json_structure
 
-
-
     @classmethod
-    def register_options(cls, parser):     
+    def register_options(cls, parser):
         """
         Registers command line options for ClingraphBackend.
         """
         ClingoBackend.register_options(parser)
 
-        parser.add_argument('--clingraph-files',
-                        help = textwrap.dedent('''\
+        parser.add_argument(
+            "--clingraph-files",
+            help=textwrap.dedent(
+                """\
                             A visualization encoding that will be used to generate the graph facts
                             by calling clingo with the input.
-                            This encoding is expected to have only one stable model.'''),
-                        # type=argparse.FileType('r'),
-                        nargs='+',
-                        metavar='')
+                            This encoding is expected to have only one stable model."""
+            ),
+            # type=argparse.FileType('r'),
+            nargs="+",
+            metavar="",
+        )
 
-        parser.add_argument('--prefix',
-                        default = '',
-                        help = textwrap.dedent('''\
+        parser.add_argument(
+            "--prefix",
+            default="",
+            help=textwrap.dedent(
+                """\
                             Prefix expected in all the considered facts.
-                            Example: --prefix=viz_ will look for predicates named viz_node, viz_edge etc.'''),
-                        type=str,
-                        metavar='')
+                            Example: --prefix=viz_ will look for predicates named viz_node, viz_edge etc."""
+            ),
+            type=str,
+            metavar="",
+        )
 
-        parser.add_argument('--default-graph',
-                        default = 'default',
-                        help = textwrap.dedent('''\
+        parser.add_argument(
+            "--default-graph",
+            default="default",
+            help=textwrap.dedent(
+                """\
                         The name of the default graph.
                         All nodes and edges with arity 1 will be assigned to this graph
-                            (default: %(default)s)'''),
-                        type=str,
-                        metavar='')
+                            (default: %(default)s)"""
+            ),
+            type=str,
+            metavar="",
+        )
 
-        parser.add_argument('--select-graph',
-                help = textwrap.dedent('''\
+        parser.add_argument(
+            "--select-graph",
+            help=textwrap.dedent(
+                """\
                     Select one of the graphs by name.
-                    Can appear multiple times to select multiple graphs'''),
-                type=str,
-                action='append',
-                nargs='?',
-                metavar="")
+                    Can appear multiple times to select multiple graphs"""
+            ),
+            type=str,
+            action="append",
+            nargs="?",
+            metavar="",
+        )
 
-        parser.add_argument('--select-model',
-                help = textwrap.dedent('''\
+        parser.add_argument(
+            "--select-model",
+            help=textwrap.dedent(
+                """\
                     Select only one of the models when using a json input.
                     Defined by a number starting in index 0.
-                    Can appear multiple times to select multiple models.'''),
-                type=int,
-                action='append',
-                nargs='?',
-                metavar="")
+                    Can appear multiple times to select multiple models."""
+            ),
+            type=int,
+            action="append",
+            nargs="?",
+            metavar="",
+        )
 
-        parser.add_argument('--name-format',
-                    help = textwrap.dedent('''\
+        parser.add_argument(
+            "--name-format",
+            help=textwrap.dedent(
+                """\
                         An optional string to format the name when saving multiple files,
                         this string can reference parameters `{graph_name}` and `{model_number}`.
                         Example `new_version-{graph_name}-{model_number}`
                         (default: `{graph_name}` or
-                                `{model_number}/{graph_name}` for multi model functionality from json)'''),
-                    type=str,
-                    metavar='')
+                                `{model_number}/{graph_name}` for multi model functionality from json)"""
+            ),
+            type=str,
+            metavar="",
+        )
 
-        parser.add_argument('--dir',
-                        default = 'out',
-                        help = textwrap.dedent('''\
+        parser.add_argument(
+            "--dir",
+            default="out",
+            help=textwrap.dedent(
+                """\
                             Directory for writing the output files
-                                (default: %(default)s)'''),
-                        type=str,
-                        metavar='')
+                                (default: %(default)s)"""
+            ),
+            type=str,
+            metavar="",
+        )
 
-        parser.add_argument('--type',
-                    default = 'graph',
-                    choices=['graph', 'digraph'],
-                    help = textwrap.dedent('''\
+        parser.add_argument(
+            "--type",
+            default="graph",
+            choices=["graph", "digraph"],
+            help=textwrap.dedent(
+                """\
                         The type of the graph
                         {graph|digraph}
-                            (default: %(default)s)'''),
-                    type=str,
-                    metavar='')
+                            (default: %(default)s)"""
+            ),
+            type=str,
+            metavar="",
+        )
 
-        parser.add_argument('--engine',
-                        default = 'dot',
-                        choices=["dot","neato","twopi","circo","fdp","osage","patchwork","sfdp"],
-                        help = textwrap.dedent('''\
+        parser.add_argument(
+            "--engine",
+            default="dot",
+            choices=[
+                "dot",
+                "neato",
+                "twopi",
+                "circo",
+                "fdp",
+                "osage",
+                "patchwork",
+                "sfdp",
+            ],
+            help=textwrap.dedent(
+                """\
                             Layout command used by graphviz
                             {dot|neato|twopi|circo|fdp|osage|patchwork|sfdp}
-                                (default: %(default)s)'''),
-                        type=str,
-                        metavar="")
+                                (default: %(default)s)"""
+            ),
+            type=str,
+            metavar="",
+        )
 
-        parser.add_argument('--disable-saved-to-file',
-                    action='store_true',
-                    help='Disable image saved to file')
- 
+        parser.add_argument(
+            "--disable-saved-to-file",
+            action="store_true",
+            help="Disable image saved to file",
+        )
 
     # ---------------------------------------------
     # Private methods
     # ---------------------------------------------
 
-    def _compute_clingraph_graphs(self,prg):
+    def _compute_clingraph_graphs(self, prg):
         fbs = []
         ctl = Control("0")
         for f in self._clingraph_files:
             ctl.load(f)
-        ctl.add("base",[],prg)
-        ctl.ground([("base",[])],ClingraphContext())
+        ctl.add("base", [], prg)
+        ctl.ground([("base", [])], ClingraphContext())
 
         ctl.solve(on_model=lambda m: fbs.append(Factbase.from_model(m)))
         if self._select_model is not None:
             for m in self._select_model:
-                if m>=len(fbs):
+                if m >= len(fbs):
                     raise ValueError(f"Invalid model number selected {m}")
-            fbs = [f if i in self._select_model else None
-                        for i, f in enumerate(fbs) ]
-
-        
+            fbs = [f if i in self._select_model else None for i, f in enumerate(fbs)]
 
         graphs = compute_graphs(fbs, graphviz_type=self._type)
 
         return graphs
 
-    def _save_clingraph_graphs_to_file(self,graphs):
+    def _save_clingraph_graphs_to_file(self, graphs):
         if self._select_graph is not None:
-            graphs = [{g_name:g for g_name, g in graph.items() if g_name in self._select_graph} for graph in graphs]
-        write_arguments = {"directory":self._dir, "name_format":self._name_format}
-        paths = render(graphs,
-                format='png',
-                engine=self._engine,
-                view=False,
-                **write_arguments)
+            graphs = [
+                {
+                    g_name: g
+                    for g_name, g in graph.items()
+                    if g_name in self._select_graph
+                }
+                for graph in graphs
+            ]
+        write_arguments = {"directory": self._dir, "name_format": self._name_format}
+        paths = render(
+            graphs, format="png", engine=self._engine, view=False, **write_arguments
+        )
         self._logger.debug("Clingraph saved images:")
         self._logger.debug(paths)
 
-    
-    def _get_mode_filled_with_base_64_images_from_graphs(self,graphs):
+    def _get_mode_filled_with_base_64_images_from_graphs(self, graphs):
         model = self._model
 
         kept_symbols = list(model.get_elements()) + list(model.get_callbacks())
 
         filled_attributes = []
-    
+
         # TODO - Improve efficiency of filling attributes
         for attribute in model.get_attributes():
             if str(attribute.key) == self._attribute_image_key:
-                attribute_value = StandardTextProcessing.parse_string_with_quotes(str(attribute.value))
+                attribute_value = StandardTextProcessing.parse_string_with_quotes(
+                    str(attribute.value)
+                )
 
-                if attribute_value.startswith(self._attribute_image_value) and attribute_value != "clingraph":
-                    splits = attribute_value.split(self._attribute_image_value_seperator)
+                if (
+                    attribute_value.startswith(self._attribute_image_value)
+                    and attribute_value != "clingraph"
+                ):
+                    splits = attribute_value.split(
+                        self._attribute_image_value_seperator
+                    )
                     splits.pop(0)
-                    rest = ""   
+                    rest = ""
                     for split in splits:
                         rest = rest + split
 
-                    key_image = self._create_image_from_graph(graphs, key = rest)
+                    key_image = self._create_image_from_graph(graphs, key=rest)
 
                     base64_key_image = self._convertImageToBase64String(key_image)
 
-                    filled_attributes.append(AttributeDao(Raw(Function(str(attribute.id),[])), Raw(Function(str(attribute.key),[])), Raw(String(str(base64_key_image)))))
+                    filled_attributes.append(
+                        AttributeDao(
+                            Raw(Function(str(attribute.id), [])),
+                            Raw(Function(str(attribute.key), [])),
+                            Raw(String(str(base64_key_image))),
+                        )
+                    )
                 else:
                     filled_attributes.append(attribute)
             else:
                 filled_attributes.append(attribute)
 
-        return ClinguinModel(clorm.FactBase(copy.deepcopy(kept_symbols + filled_attributes)))
+        return ClinguinModel(
+            clorm.FactBase(copy.deepcopy(kept_symbols + filled_attributes))
+        )
 
-
-    def _create_image_from_graph(self, graphs, position = None, key = None):
+    def _create_image_from_graph(self, graphs, position=None, key=None):
         graphs = graphs[0]
 
-        if position is not None: 
-            if (len(graphs)-1) >= position:
+        if position is not None:
+            if (len(graphs) - 1) >= position:
                 graph = graphs[list(graphs.keys())[position]]
             else:
                 self._logger.error("Attempted to access not valid position")
@@ -272,9 +336,5 @@ class ClingraphBackend(ClingoBackend):
 
     def _convertImageToBase64String(self, img):
         encoded = base64.b64encode(img)
-        decoded = encoded.decode(self._encoding)    
+        decoded = encoded.decode(self._encoding)
         return decoded
-
-
-
-

--- a/clinguin/server/application/backends/explanation_backend.py
+++ b/clinguin/server/application/backends/explanation_backend.py
@@ -21,28 +21,29 @@ class ExplanationBackend(ClingoBackend):
     """
 
     def __init__(self, args):
-        self._muc=None
+        self._muc = None
         self._lit2symbol = {}
         self._mc_base_assumptions = set()
         self._last_prg = None
         super().__init__(args)
         for s in self._ctl.symbolic_atoms:
-            if s.symbol.match('initial',3):
+            if s.symbol.match("initial", 3):
                 self._mc_base_assumptions.add(s.symbol)
                 self._add_symbol_to_dict(s.symbol)
         self._assumptions = self._mc_base_assumptions.copy()
-    
+
     # ---------------------------------------------
     # Private methods
     # ---------------------------------------------
 
-    def _add_symbol_to_dict(self,symbol):
+    def _add_symbol_to_dict(self, symbol):
         lit = self._ctl.symbolic_atoms[symbol].literal
-        self._lit2symbol[lit]=symbol
-
+        self._lit2symbol[lit] = symbol
 
     def _solve_core(self, assumptions):
-        with self._ctl.solve(assumptions=[(a,True) for a in assumptions], yield_=True) as solve_handle:
+        with self._ctl.solve(
+            assumptions=[(a, True) for a in assumptions], yield_=True
+        ) as solve_handle:
             satisfiable = solve_handle.get().satisfiable
             core = [self._lit2symbol[index] for index in solve_handle.core()]
         return satisfiable, core
@@ -57,7 +58,7 @@ class ExplanationBackend(ClingoBackend):
         probe_set = []
 
         for i, assumption in enumerate(assumption_set):
-            working_set = assumption_set[i+1:]
+            working_set = assumption_set[i + 1 :]
             sat, _ = self._solve_core(assumptions=working_set + probe_set)
             if sat:
                 probe_set.append(assumption)
@@ -67,15 +68,18 @@ class ExplanationBackend(ClingoBackend):
 
         return probe_set
 
-
     # ---------------------------------------------
     # Overwrite
     # ---------------------------------------------
 
     def _update_model(self):
         try:
-            self._last_prg = ClinguinModel.get_cautious_brave(self._ctl,self._assumptions)
-            self._model = ClinguinModel.from_ui_file_and_program(self._ctl,self._ui_files,self._last_prg,self._assumptions)
+            self._last_prg = ClinguinModel.get_cautious_brave(
+                self._ctl, self._assumptions
+            )
+            self._model = ClinguinModel.from_ui_file_and_program(
+                self._ctl, self._ui_files, self._last_prg, self._assumptions
+            )
 
         except NoModelError as e:
             self._logger.info("UNSAT Answer, will add explanation")
@@ -85,9 +89,9 @@ class ExplanationBackend(ClingoBackend):
             prg = self._last_prg
             for s in muc_core:
                 prg = prg + f"_muc({str(s)})."
-            self._model = ClinguinModel.from_ui_file_and_program(self._ctl,self._ui_files,prg,self._assumptions)
-
-    
+            self._model = ClinguinModel.from_ui_file_and_program(
+                self._ctl, self._ui_files, prg, self._assumptions
+            )
 
     # ---------------------------------------------
     # Plolicy methods (Overwrite ClingoBackend)

--- a/clinguin/server/application/backends/temporal_backend.py
+++ b/clinguin/server/application/backends/temporal_backend.py
@@ -13,6 +13,7 @@ from clinguin.server.application.backends.standard_utils.brave_cautious_helper i
 
 enable_python()
 
+
 class TemporalBackend(ClingoBackend):
     """
     TODO -> Add documentation!
@@ -21,52 +22,55 @@ class TemporalBackend(ClingoBackend):
     def __init__(self, args):
         self._step = 1
         self._last_grounded_step = 0
-        self._full_plan=None
+        self._full_plan = None
         super().__init__(args)
-        
 
     def _init_ctl(self):
-        self._step= 1
-        self._last_grounded_step= 0
-        self._full_plan=None
+        self._step = 1
+        self._last_grounded_step = 0
+        self._full_plan = None
         super()._init_ctl()
 
     def _ground(self):
         if not self._last_grounded_step:
             self._ctl.ground([("base", [])])
-        while self._step>self._last_grounded_step:
-            self._last_grounded_step+=1
+        while self._step > self._last_grounded_step:
+            self._last_grounded_step += 1
             self._ctl.ground([("step", [Number(self._step)])])
-        if self._step>1:
-            self._ctl.assign_external(Function('query',[Number(self._step-1)]),False)
-        self._ctl.assign_external(Function('query',[Number(self._step)]),True)
-
+        if self._step > 1:
+            self._ctl.assign_external(
+                Function("query", [Number(self._step - 1)]), False
+            )
+        self._ctl.assign_external(Function("query", [Number(self._step)]), True)
 
     def _find_incrementally(self):
-        if self._step>1:
-            self._ctl.assign_external(Function('check',[Number(self._step-1)]),False)
-        self._ctl.assign_external(Function('check',[Number(self._step)]),True)
+        if self._step > 1:
+            self._ctl.assign_external(
+                Function("check", [Number(self._step - 1)]), False
+            )
+        self._ctl.assign_external(Function("check", [Number(self._step)]), True)
         plan = self._find_plan()
-        
-        while plan is None or self._step>100:
-            self._step +=1
+
+        while plan is None or self._step > 100:
+            self._step += 1
             self._ground()
-            if self._step>1:
-                self._ctl.assign_external(Function('check',[Number(self._step-1)]),False)
-            self._ctl.assign_external(Function('check',[Number(self._step)]),True)
+            if self._step > 1:
+                self._ctl.assign_external(
+                    Function("check", [Number(self._step - 1)]), False
+                )
+            self._ctl.assign_external(Function("check", [Number(self._step)]), True)
             plan = self._find_plan()
 
         if self._full_plan is None:
             raise RuntimeError("No plan found before 100 steps")
 
-
         return self._full_plan
 
     def _find_plan(self):
-        self._ctl.configuration.solve.enum_mode = 'auto'
+        self._ctl.configuration.solve.enum_mode = "auto"
         hdn = self._ctl.solve(
-            assumptions=[(a,True) for a in self._assumptions],
-            yield_=True)
+            assumptions=[(a, True) for a in self._assumptions], yield_=True
+        )
         itr = iter(hdn)
         try:
             model = next(itr)
@@ -74,24 +78,23 @@ class TemporalBackend(ClingoBackend):
             hdn.cancel()
         except StopIteration:
             hdn.cancel()
-            self._full_plan=None
-        
-        return self._full_plan
+            self._full_plan = None
 
+        return self._full_plan
 
     def find_plan(self):
         if not self._full_plan:
             self._find_incrementally()
 
-        symbols = "\n".join([str(s)+"." for s in self._full_plan])
-        wctl = ClinguinModel.wid_control(self._ui_files,symbols)
+        symbols = "\n".join([str(s) + "." for s in self._full_plan])
+        wctl = ClinguinModel.wid_control(self._ui_files, symbols)
         self._model = ClinguinModel.from_ctl(wctl)
         return self.get()
 
     def assume_and_step(self, predicate):
         predicate_symbol = parse_term(predicate)
         self._assumptions.add(predicate_symbol)
-        self._step +=1
+        self._step += 1
         self._ground()
         self._end_browsing()
         self._update_model()
@@ -99,7 +102,6 @@ class TemporalBackend(ClingoBackend):
 
     def remove_assumption(self, predicate):
         raise NotImplementedError()
-
 
     def next_solution(self):
         raise NotImplementedError()

--- a/clinguin/server/application/callback.py
+++ b/clinguin/server/application/callback.py
@@ -8,6 +8,7 @@ class CallbackDto:
     """
     This class represents a Callback that is Json convertible. Therefore objects of this class are part of the hierarchy that will get converted to Json by the endpoints on sending the reply.
     """
+
     def __init__(self, id, action, policy):
         self.id = str(id)
         self.action = str(action)

--- a/clinguin/server/application/clinguin_backend.py
+++ b/clinguin/server/application/clinguin_backend.py
@@ -14,7 +14,7 @@ class ClinguinBackend(CustomArgs):
     """
 
     def __init__(self, args):
-        self._logger = logging.getLogger(args.log_args['name'])
+        self._logger = logging.getLogger(args.log_args["name"])
         self.args = args
 
     def get(self):

--- a/clinguin/server/application/element.py
+++ b/clinguin/server/application/element.py
@@ -3,6 +3,7 @@ Module that contains the ElementDto class.
 """
 import json
 
+
 class ElementDto:
     """
     The class that represents elements that are Json convertible, i.e. these components are the heart of the Json convertible hierarchy.

--- a/clinguin/server/application/standard_json_encoder.py
+++ b/clinguin/server/application/standard_json_encoder.py
@@ -11,6 +11,7 @@ from .element import ElementDto
 from .attribute import AttributeDto
 from .callback import CallbackDto
 
+
 class StandardJsonEncoder:
     """
     The standrd json encoder is responsible for converting a ClinguinModel into a json hierarchy.
@@ -29,7 +30,7 @@ class StandardJsonEncoder:
         """
         elements_dict = {}
 
-        root = ElementDto('root', 'root', 'root')
+        root = ElementDto("root", "root", "root")
         elements_dict[str(root.id)] = root
 
         cls._generate_hierarchy(model, root, elements_dict)
@@ -52,34 +53,45 @@ class StandardJsonEncoder:
         elements_info = {}
 
         for w in model.get_elements():
-            elements_info[w.id] = {'parent': w.parent, 'type': w.type}
+            elements_info[w.id] = {"parent": w.parent, "type": w.type}
             dependency.append((w.id, w.parent))
 
         DG = nx.DiGraph(dependency)
         order = list(reversed(list(nx.topological_sort(DG))))
 
         attrs = model.get_attributesGrouped()
-        attrs = {a[0]:list(a[1]) for a in attrs}
+        attrs = {a[0]: list(a[1]) for a in attrs}
         cbs = model.get_callbacksGrouped()
-        cbs = {a[0]:list(a[1]) for a in cbs}
+        cbs = {a[0]: list(a[1]) for a in cbs}
 
         for element_id in order:
             if str(element_id) == str(hierarchy_root.id):
                 continue
 
             if not element_id in elements_info:
-                logger.critical("The provided element id (ID : %s) could not be found!", str(element_id))
-                raise Exception("The provided element id (ID : " + str(element_id) + ") could not be found!")
+                logger.critical(
+                    "The provided element id (ID : %s) could not be found!",
+                    str(element_id),
+                )
+                raise Exception(
+                    "The provided element id (ID : "
+                    + str(element_id)
+                    + ") could not be found!"
+                )
 
-            type = elements_info[element_id]['type']
-            parent = elements_info[element_id]['parent']
+            type = elements_info[element_id]["type"]
+            parent = elements_info[element_id]["parent"]
             element = ElementDto(element_id, type, parent)
 
             if element_id in attrs:
-                elem_attributes = [AttributeDto(a.id, a.key, a.value) for a in attrs[element_id]]
+                elem_attributes = [
+                    AttributeDto(a.id, a.key, a.value) for a in attrs[element_id]
+                ]
                 element.set_attributes(elem_attributes)
             if element_id in cbs:
-                elem_callbacks = [CallbackDto(a.id, a.action, a.policy) for a in cbs[element_id]]
+                elem_callbacks = [
+                    CallbackDto(a.id, a.action, a.policy) for a in cbs[element_id]
+                ]
                 element.set_callbacks(elem_callbacks)
 
             elements_dict[str(element_id)] = element

--- a/clinguin/server/data/attribute.py
+++ b/clinguin/server/data/attribute.py
@@ -3,10 +3,12 @@ Module that contains the AttributeDao.
 """
 from clorm import Predicate, RawField
 
+
 class AttributeDao(Predicate):
     """
     Class for CLORM (clingo-object-relational-mapping), i.e. for accessing attributes in a factbase.
     """
+
     id = RawField
     key = RawField
     value = RawField
@@ -15,4 +17,5 @@ class AttributeDao(Predicate):
         """
         Meta class
         """
+
         name = "attribute"

--- a/clinguin/server/data/callback.py
+++ b/clinguin/server/data/callback.py
@@ -3,6 +3,7 @@ Module that contains the CallbackDao.
 """
 from clorm import Predicate, RawField
 
+
 class CallbackDao(Predicate):
     """
     Class for CLORM (clingo-object-relational-mapping), i.e. for accessing callbacks in a factbase.
@@ -16,4 +17,5 @@ class CallbackDao(Predicate):
         """
         Meta class
         """
+
         name = "callback"

--- a/clinguin/server/data/clinguin_model.py
+++ b/clinguin/server/data/clinguin_model.py
@@ -5,7 +5,7 @@ import logging
 import clorm
 
 from clorm import Raw
-from clingo import Control,parse_term
+from clingo import Control, parse_term
 from clingo.symbol import Function, Number, String
 
 from clinguin.utils import NoModelError, Logger
@@ -13,6 +13,7 @@ from clinguin.utils import NoModelError, Logger
 from .element import ElementDao
 from .attribute import AttributeDao
 from .callback import CallbackDao
+
 
 class ClinguinModel:
     """
@@ -37,11 +38,11 @@ class ClinguinModel:
         """
         Creates a ClinguinModel from paths of ui files and assumptions.
         """
-        prg = cls.get_cautious_brave(ctl,assumptions)
-        return cls.from_ui_file_and_program(ctl,ui_files,prg,assumptions)
+        prg = cls.get_cautious_brave(ctl, assumptions)
+        return cls.from_ui_file_and_program(ctl, ui_files, prg, assumptions)
 
     @classmethod
-    def from_ui_file_and_program(cls, ctl, ui_files, prg,assumptions=None):
+    def from_ui_file_and_program(cls, ctl, ui_files, prg, assumptions=None):
         """
         Creates a ClinguinModel from a Clingo control object, paths of the ui-files and a logic program provided as a string (prg is a string which contains a logic program)
         """
@@ -59,51 +60,52 @@ class ClinguinModel:
         return model
 
     @classmethod
-    def wid_control(cls, ui_files, extra_prg="", assumptions =None):
+    def wid_control(cls, ui_files, extra_prg="", assumptions=None):
         """
         Generates a ClingoControl Object from paths of ui files and extra parts of a logic program given by a string.
         """
-        wctl = Control(['0','--warn=none'])
+        wctl = Control(["0", "--warn=none"])
         for f in ui_files:
             try:
                 wctl.load(str(f))
             except Exception as e:
                 logger = logging.getLogger(Logger.server_logger_name)
-                logger.critical("File %s  could not be loaded - likely not existant or syntax error in file!", str(f))
+                logger.critical(
+                    "File %s  could not be loaded - likely not existant or syntax error in file!",
+                    str(f),
+                )
                 raise e
 
         if assumptions:
             for a in assumptions:
-                wctl.add("base",[],f"_assume({str(a)}).")
-        wctl.add("base",[],extra_prg)
-        wctl.add("base",[],"#show element/3. #show attribute/3. #show callback/3.")
-        wctl.ground([("base",[])])
+                wctl.add("base", [], f"_assume({str(a)}).")
+        wctl.add("base", [], extra_prg)
+        wctl.add("base", [], "#show element/3. #show attribute/3. #show callback/3.")
+        wctl.ground([("base", [])])
 
         return wctl
 
-
     @classmethod
-    def from_BC_extended_file(cls, ctl,assumptions):
+    def from_BC_extended_file(cls, ctl, assumptions):
         """
         Creates a ClinguinModel instance from a ClingoControl object and the provided assumptions.
         """
 
         logger = logging.getLogger(Logger.server_logger_name)
 
-        ctl.assign_external(parse_term('show_all'),False)
-        ctl.assign_external(parse_term('show_cautious'),False)
-        ctl.assign_external(parse_term('show_untagged'),False)
-        ctl.assign_external(parse_term('show_brave'),True)
-        brave_model = cls.from_brave_model(ctl,assumptions, logger)
+        ctl.assign_external(parse_term("show_all"), False)
+        ctl.assign_external(parse_term("show_cautious"), False)
+        ctl.assign_external(parse_term("show_untagged"), False)
+        ctl.assign_external(parse_term("show_brave"), True)
+        brave_model = cls.from_brave_model(ctl, assumptions, logger)
         # Here we could see if the user wants none tagged as cautious by default
-        ctl.assign_external(parse_term('show_brave'),False)
-        ctl.assign_external(parse_term('show_untagged'),True)
-        cautious_model = cls.from_cautious_model(ctl,assumptions, logger)
-        ctl.assign_external(parse_term('show_untagged'),False)
-        ctl.assign_external(parse_term('show_all'),True)
+        ctl.assign_external(parse_term("show_brave"), False)
+        ctl.assign_external(parse_term("show_untagged"), True)
+        cautious_model = cls.from_cautious_model(ctl, assumptions, logger)
+        ctl.assign_external(parse_term("show_untagged"), False)
+        ctl.assign_external(parse_term("show_all"), True)
 
-        return cls.combine(brave_model,cautious_model, logger)
-
+        return cls.combine(brave_model, cautious_model, logger)
 
     @classmethod
     def combine(cls, cgmodel1, cgmodel2):
@@ -120,7 +122,7 @@ class ClinguinModel:
         model = cls()
         symbols = list(m.symbols(shown=True))
         prg = model.symbols_to_prg(symbols)
-        wctl = ClinguinModel.wid_control(ui_files,prg)
+        wctl = ClinguinModel.wid_control(ui_files, prg)
 
         model_symbols = None
         with wctl.solve(yield_=True) as result:
@@ -154,7 +156,7 @@ class ClinguinModel:
         # c_prg = self.tag_cautious_prg(cautious_model)
         c_prg = model.symbols_to_prg(cautious_model)
         b_prg = model.tag_brave_prg(brave_model)
-        return c_prg+b_prg
+        return c_prg + b_prg
 
     @classmethod
     def from_ctl(cls, ctl):
@@ -167,52 +169,50 @@ class ClinguinModel:
         model._set_fb_symbols(model_symbols)
         return model
 
-
-    def add_message(self,title,message):
+    def add_message(self, title, message):
         """
         Adds a ''Message'' (aka. Notification/Pop-Up) for the user with a certain title and message.
         """
-        self.add_element("message","message","window")
-        self.add_attribute("message","title",title)
-        self.add_attribute("message","message",message)
+        self.add_element("message", "message", "window")
+        self.add_attribute("message", "title", title)
+        self.add_attribute("message", "message", message)
 
     def tag(self, model, tag):
         tagged = []
         for s in model:
-            tagged.append(Function(tag,[s]))
+            tagged.append(Function(tag, [s]))
         return tagged
 
-    def symbols_to_prg(self,symbols):
-        return "\n".join([str(s)+"." for s in symbols])
+    def symbols_to_prg(self, symbols):
+        return "\n".join([str(s) + "." for s in symbols])
 
     def tag_brave_prg(self, model):
-        tagged = self.tag(model,'_b')
+        tagged = self.tag(model, "_b")
         return self.symbols_to_prg(tagged)
 
     def tag_cautious_prg(self, model):
-        tagged = self.tag(model,'_c')
+        tagged = self.tag(model, "_c")
         return self.symbols_to_prg(tagged)
 
-
     def add_element(self, id, t, parent):
-        if type(id)==str:
-            id = Function(id,[])
-        if type(t)==str:
-            t = Function(t,[])
-        if type(parent)==str:
-            parent = Function(parent,[])
-        self._factbase.add(ElementDao(Raw(id),Raw(t),Raw(parent)))
+        if type(id) == str:
+            id = Function(id, [])
+        if type(t) == str:
+            t = Function(t, [])
+        if type(parent) == str:
+            parent = Function(parent, [])
+        self._factbase.add(ElementDao(Raw(id), Raw(t), Raw(parent)))
 
     def add_attribute(self, id, key, value):
-        if type(id)==str:
-            id = Function(id,[])
-        if type(key)==str:
-            key = Function(key,[])
-        if type(value)==str:
+        if type(id) == str:
+            id = Function(id, [])
+        if type(key) == str:
+            key = Function(key, [])
+        if type(value) == str:
             value = String(value)
-        if type(value)==int:
+        if type(value) == int:
             value = Number(value)
-        self._factbase.add(AttributeDao(Raw(id),Raw(key),Raw(value)))
+        self._factbase.add(AttributeDao(Raw(id), Raw(key), Raw(value)))
 
     def filter_elements(self, condition):
         elements = self.get_elements()
@@ -222,7 +222,9 @@ class ClinguinModel:
         callbacks = self.get_callbacks()
         kept_attributes = [e for e in attributes if e.id in kept_ids]
         kept_callbacks = [e for e in callbacks if e.id in kept_ids]
-        self._factbase=clorm.FactBase(kept_elements+kept_callbacks+kept_attributes)
+        self._factbase = clorm.FactBase(
+            kept_elements + kept_callbacks + kept_attributes
+        )
 
     def get_elements(self):
         return self._factbase.query(ElementDao).all()
@@ -240,22 +242,27 @@ class ClinguinModel:
         return self._factbase.query(CallbackDao).all()
 
     def get_attributesForElementId(self, element_id):
-        return self._factbase.query(AttributeDao).where(
-            AttributeDao.id == element_id).all()
+        return (
+            self._factbase.query(AttributeDao)
+            .where(AttributeDao.id == element_id)
+            .all()
+        )
 
     def get_callbacksForElementId(self, element_id):
-        return self._factbase.query(CallbackDao).where(
-            CallbackDao.id == element_id).all()
+        return (
+            self._factbase.query(CallbackDao).where(CallbackDao.id == element_id).all()
+        )
 
     def _set_fb_symbols(self, symbols):
         self._factbase = clorm.unify(self.unifiers, symbols)
 
-    def _compute(self,ctl, assumptions):
-        with ctl.solve(assumptions=[(a,True) for a in assumptions],
-                yield_=True) as result:
+    def _compute(self, ctl, assumptions):
+        with ctl.solve(
+            assumptions=[(a, True) for a in assumptions], yield_=True
+        ) as result:
             model_symbols = None
             for m in result:
-                model_symbols = m.symbols(shown=True,atoms=False)
+                model_symbols = m.symbols(shown=True, atoms=False)
             if model_symbols is None:
                 self._logger.error("Got an UNSAT result with the given encoding.")
                 self._logger.error("The operation can't be performed")
@@ -263,29 +270,27 @@ class ClinguinModel:
         return list(model_symbols)
 
     def compute_brave(self, ctl, assumptions):
-        ctl.configuration.solve.opt_mode = 'ignore'
-        ctl.configuration.solve.enum_mode = 'brave'
+        ctl.configuration.solve.opt_mode = "ignore"
+        ctl.configuration.solve.enum_mode = "brave"
         l = self._compute(ctl, assumptions)
         self._logger.debug("BRAVE CONSEQUENCES:")
         self._logger.debug([str(s) for s in l])
         return l
 
     def compute_cautious(self, ctl, assumptions):
-        ctl.configuration.solve.opt_mode = 'ignore'
-        ctl.configuration.solve.enum_mode = 'cautious'
+        ctl.configuration.solve.opt_mode = "ignore"
+        ctl.configuration.solve.enum_mode = "cautious"
         l = self._compute(ctl, assumptions)
         self._logger.debug("CAUTIOUS CONSEQUENCES:")
         self._logger.debug([str(s) for s in l])
         return l
 
     def compute_auto(self, ctl, assumptions):
-        ctl.configuration.solve.enum_mode = 'auto'
+        ctl.configuration.solve.enum_mode = "auto"
         l = self._compute(ctl, assumptions)
         self._logger.debug("STABLE MODEL")
         self._logger.debug([str(s) for s in l])
         return l
 
-
     def get_factbase(self):
         return self._factbase
-

--- a/clinguin/server/data/element.py
+++ b/clinguin/server/data/element.py
@@ -3,10 +3,12 @@ Module that contains the ElementDao.
 """
 from clorm import Predicate, RawField
 
+
 class ElementDao(Predicate):
     """
     Class for CLORM (clingo-object-relational-mapping), i.e. for accessing elements in a factbase.
     """
+
     id = RawField
     type = RawField
     parent = RawField
@@ -15,4 +17,5 @@ class ElementDao(Predicate):
         """
         Meta class
         """
+
         name = "element"

--- a/clinguin/server/presentation/backend_policy_dto.py
+++ b/clinguin/server/presentation/backend_policy_dto.py
@@ -4,8 +4,10 @@ Module that contains the BackendPolicyDto
 
 from pydantic import BaseModel
 
+
 class BackendPolicyDto(BaseModel):
     """
     Needed by the endpoints to get convert the transported json into something useful for the backend.
     """
+
     function: str

--- a/clinguin/server/presentation/endpoints.py
+++ b/clinguin/server/presentation/endpoints.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter
 import clingo
 
 from clinguin.utils import Logger
+
 # Self Defined
 from .endpoints_helper import EndpointsHelper
 from .backend_policy_dto import BackendPolicyDto
@@ -23,9 +24,10 @@ class Endpoints:
         standard_executor -> Json : Returns the default GUI representation as Json that the Backend provides.
         policy_executor -> Json : Executes a policy defined by the Json passed with the Post request.
     """
+
     def __init__(self, args) -> None:
-        Logger.setup_logger(args.log_args, process = "server")
-        self._logger = logging.getLogger(args.log_args['name'])
+        Logger.setup_logger(args.log_args, process="server")
+        self._logger = logging.getLogger(args.log_args["name"])
 
         self.router = APIRouter()
 
@@ -38,11 +40,11 @@ class Endpoints:
 
     async def health(self):
         self._logger.info("--> Health")
-        cuin = metadata('clinguin')
+        cuin = metadata("clinguin")
         return {
             "name": cuin["name"],
             "version": cuin["version"],
-            "description": cuin["summary"]
+            "description": cuin["summary"],
         }
 
     async def standard_executor(self):
@@ -53,16 +55,18 @@ class Endpoints:
         self._logger.debug("Got endpoint")
         symbol = clingo.parse_term(backend_call_string.function)
         function_name = symbol.name
-        function_arguments = (
-            list(map(str, symbol.arguments)))
+        function_arguments = list(map(str, symbol.arguments))
 
         call_args = ",".join(function_arguments)
-        self._logger.info("--> %s:   %s(%s))", self._backend.__class__.__name__, function_name, call_args)
+        self._logger.info(
+            "--> %s:   %s(%s))",
+            self._backend.__class__.__name__,
+            function_name,
+            call_args,
+        )
 
         result = EndpointsHelper.call_function(
-            self._backend,
-            function_name,
-            function_arguments,
-            {})
-        
+            self._backend, function_name, function_arguments, {}
+        )
+
         return result

--- a/clinguin/server/presentation/endpoints_helper.py
+++ b/clinguin/server/presentation/endpoints_helper.py
@@ -27,7 +27,6 @@ class EndpointsHelper:
         snake_case_name = name
         camel_case_name = CaseConverter.snake_case_to_camel_case(snake_case_name)
 
-
         if hasattr(backend, snake_case_name):
             function = getattr(backend, snake_case_name)
             found = True
@@ -43,10 +42,9 @@ class EndpointsHelper:
                 logger.error(e)
                 logger.error(traceback.format_exc())
                 return SERVER_ERROR_ALERT
-                
+
                 # return sever_error_json(e)
         else:
             error_string = "Could not find function: " + name + " :in backend"
             logger.error(error_string)
             raise Exception(error_string)
-

--- a/clinguin/show_frontend_syntax_enum.py
+++ b/clinguin/show_frontend_syntax_enum.py
@@ -3,12 +3,12 @@ Defines the possibilities how to show the syntax.
 """
 from enum import Enum, auto
 
+
 class ShowFrontendSyntaxEnum(Enum):
     """
     Defines the possibilities how to show the syntax.
     """
+
     NONE = auto()
     SHOW = auto()
     FULL = auto()
-
-

--- a/clinguin/utils/__init__.py
+++ b/clinguin/utils/__init__.py
@@ -8,6 +8,10 @@ from .custom_args import CustomArgs
 from .case_converter import CaseConverter
 from .attribute_types.utils.standard_text_processing import StandardTextProcessing
 
-__all__ = [Logger.__name__, CustomArgs.__name__, CaseConverter.__name__,NoModelError.__name__,StandardTextProcessing.__name__]
-
-
+__all__ = [
+    Logger.__name__,
+    CustomArgs.__name__,
+    CaseConverter.__name__,
+    NoModelError.__name__,
+    StandardTextProcessing.__name__,
+]

--- a/clinguin/utils/attribute_types/__init__.py
+++ b/clinguin/utils/attribute_types/__init__.py
@@ -16,6 +16,19 @@ from .popup_types import PopupTypesType
 from .font_families import FontFamiliesType
 from .font_weight import FontWeightType
 
-__all__ = [Type.__name__, BooleanType.__name__, IntegerType.__name__, FloatType.__name__, StringType.__name__, ColorType.__name__, EnumType.__name__, ChildLayoutType.__name__, SymbolType.__name__, ImageType.__name__, PathType.__name__,PopupTypesType.__name__,FontFamiliesType.__name__, FontWeightType.__name__]
-
-
+__all__ = [
+    Type.__name__,
+    BooleanType.__name__,
+    IntegerType.__name__,
+    FloatType.__name__,
+    StringType.__name__,
+    ColorType.__name__,
+    EnumType.__name__,
+    ChildLayoutType.__name__,
+    SymbolType.__name__,
+    ImageType.__name__,
+    PathType.__name__,
+    PopupTypesType.__name__,
+    FontFamiliesType.__name__,
+    FontWeightType.__name__,
+]

--- a/clinguin/utils/attribute_types/boolean.py
+++ b/clinguin/utils/attribute_types/boolean.py
@@ -5,6 +5,7 @@ Module that contains the BooleanType class.
 from .type import Type
 from .utils.standard_text_processing import StandardTextProcessing
 
+
 class BooleanType(Type):
     """
     Class that resembles a boolean value in the attributes.
@@ -21,9 +22,7 @@ class BooleanType(Type):
         else:
             logger.error("Could not parse string to boolean: " + parsed_string)
             raise Exception("Could not parse string to boolean: " + parsed_string)
-            
-
 
     @classmethod
     def description(cls):
-        return "For the boolean type, either true or false are allowed - either as string or as a clingo-symbol. If one provides it as a string, it is case-insensitive."     
+        return "For the boolean type, either true or false are allowed - either as string or as a clingo-symbol. If one provides it as a string, it is case-insensitive."

--- a/clinguin/utils/attribute_types/child_layout.py
+++ b/clinguin/utils/attribute_types/child_layout.py
@@ -31,8 +31,9 @@ class ChildLayoutType(EnumType):
             return cls.RELSTATIC
         else:
             logger.error("Could not parse " + parsed_string + " to child_layout type.")
-            raise Exception("Could not parse " + parsed_string + " to child_layout type.")
-        
+            raise Exception(
+                "Could not parse " + parsed_string + " to child_layout type."
+            )
 
     @classmethod
     def description(cls):

--- a/clinguin/utils/attribute_types/color.py
+++ b/clinguin/utils/attribute_types/color.py
@@ -5,6 +5,7 @@ This module contains the ColorType class.
 from .type import Type
 from .utils.standard_text_processing import StandardTextProcessing
 
+
 class ColorType(Type):
     """
     The color type is used for specifying a color.
@@ -16,7 +17,6 @@ class ColorType(Type):
 
         return parsed_string
 
-
     @classmethod
     def description(cls):
-        return "One can specify the color either by providing a simple-color symbol or string (like white, black, etc.), or by specifying it directly via a 9-digit hex-string, where the definition of it is: \"#RRRGGGBBB\", where R means Red, G means Green and B means Blue. E.g. black is \"#000000000\", red is \"#fff000000\", green \"#000fff000\", blue \"#000000fff\" and white \"fffffffff\"."
+        return 'One can specify the color either by providing a simple-color symbol or string (like white, black, etc.), or by specifying it directly via a 9-digit hex-string, where the definition of it is: "#RRRGGGBBB", where R means Red, G means Green and B means Blue. E.g. black is "#000000000", red is "#fff000000", green "#000fff000", blue "#000000fff" and white "fffffffff".'

--- a/clinguin/utils/attribute_types/enum.py
+++ b/clinguin/utils/attribute_types/enum.py
@@ -5,8 +5,8 @@ This module contains the EnumType.
 from enum import Enum
 from .type import Type
 
+
 class EnumType(Type, Enum):
     """
     The EnumType shall not be directly used, only subtypes of the EnumType (like the ChildLayout) shall be used.
     """
-

--- a/clinguin/utils/attribute_types/float.py
+++ b/clinguin/utils/attribute_types/float.py
@@ -5,6 +5,7 @@ This module contains the FloatType class.
 from .type import Type
 from .utils.standard_text_processing import StandardTextProcessing
 
+
 class FloatType(Type):
     """
     The flaot type shall be used, when the attribute-value is float like.
@@ -22,4 +23,4 @@ class FloatType(Type):
 
     @classmethod
     def description(cls):
-        return "Is a float type. A float must be specified as a string (e.g. \"5.98\")."
+        return 'Is a float type. A float must be specified as a string (e.g. "5.98").'

--- a/clinguin/utils/attribute_types/font_families.py
+++ b/clinguin/utils/attribute_types/font_families.py
@@ -7,6 +7,7 @@ from enum import auto
 from .utils.standard_text_processing import StandardTextProcessing
 from .type import Type
 
+
 class FontFamiliesType(Type):
     """
     The FontFamlies is a type, which can be used to specify the font family of a text.
@@ -17,7 +18,6 @@ class FontFamiliesType(Type):
         parsed_string = StandardTextProcessing.parse_string_with_quotes(input)
 
         return parsed_string
-
 
     @classmethod
     def description(cls):

--- a/clinguin/utils/attribute_types/font_weight.py
+++ b/clinguin/utils/attribute_types/font_weight.py
@@ -8,6 +8,7 @@ import itertools
 from .utils.standard_text_processing import StandardTextProcessing
 from .enum import EnumType
 
+
 class FontWeightType(EnumType):
     """
     The FontWeightType is an Enum Type, which can be used to specify look and feel of text.
@@ -25,7 +26,7 @@ class FontWeightType(EnumType):
         normals = ["n", "normal"]
         bolds = ["b", "bold"]
         italics = ["i", "italic"]
-        
+
         combination = [bolds, italics]
 
         bolds_italic_list = []
@@ -54,5 +55,4 @@ class FontWeightType(EnumType):
 
     @classmethod
     def description(cls):
-        return "For the FontWeightType several different options exists - [\"i\" or \"italic\"] for italic, [\"b\" or \"bold\"] for bold and any permuation (with the delimiters \"_\", \"-\" and no delimiter) of those for both italic and bolt. Further \"normal\" exists for specifying normal font weight."
-
+        return 'For the FontWeightType several different options exists - ["i" or "italic"] for italic, ["b" or "bold"] for bold and any permuation (with the delimiters "_", "-" and no delimiter) of those for both italic and bolt. Further "normal" exists for specifying normal font weight.'

--- a/clinguin/utils/attribute_types/image.py
+++ b/clinguin/utils/attribute_types/image.py
@@ -6,6 +6,7 @@ import base64
 from .type import Type
 from .utils.standard_text_processing import StandardTextProcessing
 
+
 class ImageType(Type):
     """
     The ImageType shall be used when the image is transferred from the backend to the frontend via a Base64 encoded string.
@@ -16,14 +17,13 @@ class ImageType(Type):
         parsed_string = StandardTextProcessing.parse_string_with_quotes(input)
 
         try:
-            image_initial_bytes = parsed_string.encode('utf-8')
+            image_initial_bytes = parsed_string.encode("utf-8")
             base64.b64decode(image_initial_bytes)
         except:
             logger.error("Sent image is not base64 encoded.")
             raise Exception("Sent image is not base64 encoded.")
 
         return parsed_string
-
 
     @classmethod
     def description(cls):

--- a/clinguin/utils/attribute_types/integer.py
+++ b/clinguin/utils/attribute_types/integer.py
@@ -5,6 +5,7 @@ This module contains the IntegerType class.
 from .type import Type
 from .utils.standard_text_processing import StandardTextProcessing
 
+
 class IntegerType(Type):
     """
     The IntegerType shall be used, when the attribute value is integer like.
@@ -23,5 +24,3 @@ class IntegerType(Type):
     @classmethod
     def description(cls):
         return "Specification as an integer, can be either specified as a symbol or a string."
-
-        

--- a/clinguin/utils/attribute_types/path.py
+++ b/clinguin/utils/attribute_types/path.py
@@ -7,6 +7,7 @@ from os import path
 from .type import Type
 from .utils.standard_text_processing import StandardTextProcessing
 
+
 class PathType(Type):
     """
     The PathType shall be used, when a path is specified (checks if path exists).
@@ -15,7 +16,7 @@ class PathType(Type):
     @classmethod
     def parse(cls, input: str, logger):
         parsed_string = StandardTextProcessing.parse_string_with_quotes(input)
-        
+
         if path.exists(parsed_string):
             return parsed_string
         else:

--- a/clinguin/utils/attribute_types/popup_types.py
+++ b/clinguin/utils/attribute_types/popup_types.py
@@ -6,6 +6,7 @@ from enum import auto
 from .utils.standard_text_processing import StandardTextProcessing
 from .enum import EnumType
 
+
 class PopupTypesType(EnumType):
     """
     The PopupType is an Enum Type, which can be used to specify look and feel of the message box.
@@ -33,4 +34,3 @@ class PopupTypesType(EnumType):
     @classmethod
     def description(cls):
         return "For the popup-types three different options exists: ''info'' (Default information message), ''warning'' and ''error''"
-

--- a/clinguin/utils/attribute_types/string.py
+++ b/clinguin/utils/attribute_types/string.py
@@ -5,6 +5,7 @@ This module contains the StringType class.
 from .type import Type
 from .utils.standard_text_processing import StandardTextProcessing
 
+
 class StringType(Type):
     """
     The StringType shall be used, when the attribute value is string like.
@@ -15,7 +16,6 @@ class StringType(Type):
         parsed_string = StandardTextProcessing.parse_string_with_quotes(input)
 
         return parsed_string
-
 
     @classmethod
     def description(cls):

--- a/clinguin/utils/attribute_types/symbol.py
+++ b/clinguin/utils/attribute_types/symbol.py
@@ -7,6 +7,7 @@ import clingo
 from .type import Type
 from .utils.standard_text_processing import StandardTextProcessing
 
+
 class SymbolType(Type):
     """
     This class checks if the input IS A symbol, it does not parse it to a symbol.
@@ -15,7 +16,7 @@ class SymbolType(Type):
     @classmethod
     def parse(cls, input: str, logger) -> str:
         parsed_string = StandardTextProcessing.parse_string_with_quotes(input)
-    
+
         try:
             clingo.parse_term(parsed_string)
             return parsed_string
@@ -23,7 +24,6 @@ class SymbolType(Type):
             error_string = "The string " + parsed_string + " is not a clingo symbol!"
             logger.error(error_string)
             raise Exception(error_string)
-            
 
     @classmethod
     def description(cls):

--- a/clinguin/utils/attribute_types/type.py
+++ b/clinguin/utils/attribute_types/type.py
@@ -2,18 +2,19 @@
 This module contains the Type class.
 """
 
+
 class Type:
     """
     The Type class is the super class of all Clinguin-Value-Types, i.e. each individual type must be a subtype of Type.
     """
 
     @classmethod
-    def parse(cls, input : str, logger):
+    def parse(cls, input: str, logger):
         """
         Every type must override this method. This method parses/checks the given value.
         """
         return None
-    
+
     @classmethod
     def description(cls):
         """

--- a/clinguin/utils/attribute_types/utils/standard_text_processing.py
+++ b/clinguin/utils/attribute_types/utils/standard_text_processing.py
@@ -2,6 +2,7 @@
 This module contains the StandardTextProcessing class.
 """
 
+
 class StandardTextProcessing:
     """
     The sole method parse_string_with_quotes removes unecessary quotes at the beginning and the end of a string.
@@ -10,11 +11,10 @@ class StandardTextProcessing:
     @classmethod
     def parse_string_with_quotes(cls, text):
         if len(text) > 0:
-            if text[0] == "\"":
+            if text[0] == '"':
                 text = text[1:]
         if len(text) > 0:
-            if text[len(text)-1] == "\"":
+            if text[len(text) - 1] == '"':
                 text = text[:-1]
 
         return text
- 

--- a/clinguin/utils/case_converter.py
+++ b/clinguin/utils/case_converter.py
@@ -2,6 +2,7 @@
 Module contains the CaseConverter class.
 """
 
+
 class CaseConverter:
     """
     The CaseConverter class provides functionality to convert strings from one type-case (like snake_case) to another (like camelCase).
@@ -12,8 +13,6 @@ class CaseConverter:
 
     @classmethod
     def snake_case_to_camel_case(cls, snake_case):
-        components = snake_case.split('_')
+        components = snake_case.split("_")
 
-        return components[0] + ''.join(x.title() for x in components[1:]) 
-
-
+        return components[0] + "".join(x.title() for x in components[1:])

--- a/clinguin/utils/custom_args.py
+++ b/clinguin/utils/custom_args.py
@@ -2,6 +2,7 @@
 The module contains the CustomArgs class.
 """
 
+
 class CustomArgs:
     """
     The root class of all backend- (like ClingoBackend) and gui-classes (like TkinterFrontend). Needed for argparse (with the method register_options one can specify command line arguments, that are specific to a certain class).
@@ -13,7 +14,3 @@ class CustomArgs:
     @classmethod
     def register_options(cls, parser):
         pass
-
-
-
-

--- a/clinguin/utils/errors.py
+++ b/clinguin/utils/errors.py
@@ -2,15 +2,46 @@
 This module provides different errors for clinguin.
 """
 
+
 class NoModelError(Exception):
     """
     The NoModelError is raised, if the provided logic program is unsatisfiable.
     """
+
     def __init__(self, core=None) -> None:
         super().__init__()
-        self.core = core    
+        self.core = core
 
-SERVER_ERROR_ALERT = { 'id': 'root', 'type': 'root', 'parent': 'root', 'attributes': [], 'callbacks': [], 'children': [ 
-        {'id': 'window', 'type': 'window', 'parent': 'root', 'attributes': [], 'callbacks':[], 'children': [
-            {'id': 'message', 'type': 'message', 'parent': 'window', 'callbacks':[], 'attributes': [{'id': 'message', 'key': 'message', 'value': '"Server Error (Check logs)"'}], 'children':[]},]
-        }]}
+
+SERVER_ERROR_ALERT = {
+    "id": "root",
+    "type": "root",
+    "parent": "root",
+    "attributes": [],
+    "callbacks": [],
+    "children": [
+        {
+            "id": "window",
+            "type": "window",
+            "parent": "root",
+            "attributes": [],
+            "callbacks": [],
+            "children": [
+                {
+                    "id": "message",
+                    "type": "message",
+                    "parent": "window",
+                    "callbacks": [],
+                    "attributes": [
+                        {
+                            "id": "message",
+                            "key": "message",
+                            "value": '"Server Error (Check logs)"',
+                        }
+                    ],
+                    "children": [],
+                },
+            ],
+        }
+    ],
+}

--- a/clinguin/utils/logger.py
+++ b/clinguin/utils/logger.py
@@ -5,6 +5,7 @@ Module that takes care of the custom logging config, so it contains the Logger-c
 import logging
 import os
 
+
 class Logger:
     """
     Provides methods to set the logging config appropriatly. In principle two loggers exists - one for the client (default name: clinguin_client) and one for the server (default name: clinguin_server).
@@ -15,19 +16,17 @@ class Logger:
         For colored logs.
         """
 
-        def __init__(self, msg, use_color = True):
+        def __init__(self, msg, use_color=True):
             logging.Formatter.__init__(self, msg)
             self.use_color = use_color
 
         def format(self, record):
             levelname = record.levelname
             if self.use_color and levelname in Logger.COLORS:
-                color =  Logger.COLOR_SEQ % (30 + Logger.COLORS[levelname])
+                color = Logger.COLOR_SEQ % (30 + Logger.COLORS[levelname])
                 levelname_color = color + levelname[0:4] + Logger.RESET_SEQ
                 record.levelname = levelname_color
             return logging.Formatter.format(self, record)
-
-
 
     client_logger_name = "clinguin_client"
     server_logger_name = "clinguin_server"
@@ -38,7 +37,7 @@ class Logger:
         "INFO": logging.INFO,
         "WARNING": logging.WARNING,
         "ERROR": logging.ERROR,
-        "CRITICAL": logging.CRITICAL
+        "CRITICAL": logging.CRITICAL,
     }
 
     BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
@@ -47,32 +46,35 @@ class Logger:
     BOLD_SEQ = "\033[1m"
 
     @classmethod
-    def formatter_message(cls, message, use_color = True):
+    def formatter_message(cls, message, use_color=True):
         if use_color:
-            message = message.replace("$RESET", cls.RESET_SEQ).replace("$BOLD", cls.BOLD_SEQ)
+            message = message.replace("$RESET", cls.RESET_SEQ).replace(
+                "$BOLD", cls.BOLD_SEQ
+            )
         else:
             message = message.replace("$RESET", "").replace("$BOLD", "")
         return message
 
     COLORS = {
-        'WARNING': YELLOW,
-        'INFO': GREEN,
-        'DEBUG': BLUE,
-        'CRITICAL': RED,
-        'ERROR': RED
+        "WARNING": YELLOW,
+        "INFO": GREEN,
+        "DEBUG": BLUE,
+        "CRITICAL": RED,
+        "ERROR": RED,
     }
 
     @classmethod
     def _get_log_file_path(cls, log_arg_dict):
-        log_file_path = os.path.join("logs",
-            (log_arg_dict['timestamp'] + "-" + log_arg_dict['name'] + ".log"))
+        log_file_path = os.path.join(
+            "logs", (log_arg_dict["timestamp"] + "-" + log_arg_dict["name"] + ".log")
+        )
         return log_file_path
 
     @classmethod
     def _add_shell_handler_to_logger(cls, logger, log_arg_dict):
-        shell_formatter = Logger.ColoredFormatter(log_arg_dict['format_shell'])
+        shell_formatter = Logger.ColoredFormatter(log_arg_dict["format_shell"])
 
-        logger.setLevel(cls.log_levels[log_arg_dict['level']])
+        logger.setLevel(cls.log_levels[log_arg_dict["level"]])
 
         handler_sh = logging.StreamHandler()
         handler_sh.setFormatter(shell_formatter)
@@ -81,31 +83,30 @@ class Logger:
 
     @classmethod
     def _add_file_handler_to_logger(cls, logger, log_arg_dict, log_file_path):
-        file_formatter = Logger.ColoredFormatter(log_arg_dict['format_file'])
+        file_formatter = Logger.ColoredFormatter(log_arg_dict["format_file"])
 
         with open(log_file_path, "a+") as file_object:
             file_object.write(
-                "<<<<<NEW-LOG-INSTANCE-" +
-                log_arg_dict['name'] +
-                ">>>>>\n\n")
+                "<<<<<NEW-LOG-INSTANCE-" + log_arg_dict["name"] + ">>>>>\n\n"
+            )
 
         handler_f = logging.FileHandler(log_file_path)
         handler_f.setFormatter(file_formatter)
         logger.addHandler(handler_f)
 
     @classmethod
-    def setup_logger(cls, log_arg_dict, process = None):
-        if process and process == "client": 
-            cls.client_logger_name = log_arg_dict['name']
+    def setup_logger(cls, log_arg_dict, process=None):
+        if process and process == "client":
+            cls.client_logger_name = log_arg_dict["name"]
         elif process and process == "server":
-            cls.server_logger_name = log_arg_dict['name']
+            cls.server_logger_name = log_arg_dict["name"]
 
         log_file_path = cls._get_log_file_path(log_arg_dict)
 
-        logger = logging.getLogger(log_arg_dict['name'])
-        if not log_arg_dict['shell_disabled']:
+        logger = logging.getLogger(log_arg_dict["name"])
+        if not log_arg_dict["shell_disabled"]:
             cls._add_shell_handler_to_logger(logger, log_arg_dict)
-        if log_arg_dict['file_enabled']:
+        if log_arg_dict["file_enabled"]:
             cls._add_file_handler_to_logger(logger, log_arg_dict, log_file_path)
 
     @classmethod
@@ -128,9 +129,7 @@ class Logger:
         log_file_path = cls._get_log_file_path(log_arg_dict)
 
         logger = logging.getLogger("uvicorn")
-        if not log_arg_dict['shell_disabled']:
+        if not log_arg_dict["shell_disabled"]:
             cls._add_shell_handler_to_logger(logger, log_arg_dict)
-        if log_arg_dict['file_enabled']:
+        if log_arg_dict["file_enabled"]:
             cls._add_file_handler_to_logger(logger, log_arg_dict, log_file_path)
-
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,17 +12,27 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
-autodoc_mock_imports = ["clingo","clorm","networkx","graphviz","jsonschema","fastapi","httpx","uvicorn"]
+
+sys.path.insert(0, os.path.abspath(".."))
+autodoc_mock_imports = [
+    "clingo",
+    "clorm",
+    "networkx",
+    "graphviz",
+    "jsonschema",
+    "fastapi",
+    "httpx",
+    "uvicorn",
+]
 
 # -- Project information -----------------------------------------------------
 
-project = 'clinguin'
-copyright = '2022, Alexander Beiser,Susana Hahn'
-author = 'Alexander Beiser,Susana Hahn'
+project = "clinguin"
+copyright = "2022, Alexander Beiser,Susana Hahn"
+author = "Alexander Beiser,Susana Hahn"
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = "0.0.1"
 
 
 # -- General configuration ---------------------------------------------------
@@ -31,12 +41,12 @@ release = '0.0.1'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'nbsphinx',
-    'sphinx_rtd_theme',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autosectionlabel',
-    'sphinx.ext.intersphinx'
+    "nbsphinx",
+    "sphinx_rtd_theme",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.intersphinx",
 ]
 
 napoleon_include_init_with_doc = False
@@ -44,12 +54,12 @@ napoleon_use_admonition_for_examples = False
 napoleon_use_admonition_for_references = True
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -57,26 +67,26 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
-html_theme_options = { 
-    'canonical_url': '', 
-#    'analytics_id': 'UA-XXXXXXX-1',  #  Provided by Google in your dashboard
-    'logo_only': False,
-    'display_version': True,
-    'display_version': True,
-    'prev_next_buttons_location': 'bottom',
-    'style_external_links': False,
+html_theme_options = {
+    "canonical_url": "",
+    #    'analytics_id': 'UA-XXXXXXX-1',  #  Provided by Google in your dashboard
+    "logo_only": False,
+    "display_version": True,
+    "display_version": True,
+    "prev_next_buttons_location": "bottom",
+    "style_external_links": False,
     # Toc options
-    'collapse_navigation': True,
-    'sticky_navigation': False,
-    'navigation_depth': 4,
-    'includehidden': True,
-    'titles_only': False
+    "collapse_navigation": True,
+    "sticky_navigation": False,
+    "navigation_depth": 4,
+    "includehidden": True,
+    "titles_only": False,
 }
 
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+# html_static_path = ['_static']

--- a/examples/optimization/tsp/tsp_backend.py
+++ b/examples/optimization/tsp/tsp_backend.py
@@ -1,6 +1,7 @@
 from clinguin.server.application.backends.clingraph_backend import *
 from clingo import Symbol, Number
 
+
 class TspBackend(ClingraphBackend):
 
     # Computes the set difference between the brave and cautious model.
@@ -32,22 +33,18 @@ class TspBackend(ClingraphBackend):
                     if str(c2.name) == "weight":
                         v0_w = str(c2.arguments[0])
                         v1_w = str(c2.arguments[1])
-                        
+
                         if v0 == v0_w and v1 == v1_w:
                             cost = cost + int(str(c2.arguments[2]))
-                            
 
-                        
-                #for c2 in cautious_model:
-            #print(c)
+                # for c2 in cautious_model:
+            # print(c)
 
         symb = Function("_cautious_cost", [Number(cost)])
-    
 
         print(cost)
         print(symb)
-        return symb        
-        
+        return symb
 
     def _update_model(self):
         super()._update_model()
@@ -57,12 +54,14 @@ class TspBackend(ClingraphBackend):
             assumptions = self._assumptions
 
             model = ClinguinModel()
-            
+
             cautious_model = model.compute_cautious(ctl, assumptions)
             cautious_model.append(self.calculateCautiousCost(cautious_model))
 
             brave_model = model.compute_brave(ctl, assumptions)
-            brave_cautious_difference = self.doSetDifference(brave_model, cautious_model)
+            brave_cautious_difference = self.doSetDifference(
+                brave_model, cautious_model
+            )
             # c_prg = self.tag_cautious_prg(cautious_model)
             c_prg = model.symbols_to_prg(cautious_model)
             b_prg = model.tag_brave_prg(brave_model)
@@ -75,21 +74,23 @@ class TspBackend(ClingraphBackend):
             assumption_prg = model.tag(self._assumptions, "_assumption")
             assumption_prg = model.symbols_to_prg(assumption_prg)
 
-
-
-            #prg = ClinguinModel.getCautiosBrave(self._ctl,self._assumptions)
+            # prg = ClinguinModel.getCautiosBrave(self._ctl,self._assumptions)
             prg = c_prg + b_prg + bcd_prg + atom_prg + assumption_prg
 
-            self._model = ClinguinModel.from_ui_file_and_program(self._ctl,self._ui_files,prg,self._assumptions)
+            self._model = ClinguinModel.from_ui_file_and_program(
+                self._ctl, self._ui_files, prg, self._assumptions
+            )
 
             graphs = self._compute_clingraph_graphs(prg)
 
             self._save_clingraph_graphs_to_file(graphs)
 
-            self._filled_model = self._get_mode_filled_with_base_64_images_from_graphs(graphs)
+            self._filled_model = self._get_mode_filled_with_base_64_images_from_graphs(
+                graphs
+            )
 
         except NoModelError:
-            self._model.add_message("Error","This operation can't be performed")
+            self._model.add_message("Error", "This operation can't be performed")
 
     def saveBest(self, m):
         self._best = m.symbols(shown=True, atoms=False)
@@ -111,7 +112,7 @@ class TspBackend(ClingraphBackend):
 
                 # If b in best but not in cautious, then add:
                 if not found:
-                    self._assumptions.add(b) 
+                    self._assumptions.add(b)
 
     def findMinimum(self):
 
@@ -123,20 +124,17 @@ class TspBackend(ClingraphBackend):
 
         # Get Best Model
         self._init_ctl()
-        self._ctl.add("base",[],"#minimize{C:cost(C)}.")
+        self._ctl.add("base", [], "#minimize{C:cost(C)}.")
         self._ground()
-        self._ctl.solve(on_model=lambda m:self.saveBest(m))
+        self._ctl.solve(on_model=lambda m: self.saveBest(m))
         best = list(self._best)
-        
 
         self.addBestToAtoms(cautious, best)
         print("WORKED!")
 
         self._init_ctl()
         self._ground()
- 
+
         self._update_model()
 
         return self.get()
-
-

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()


### PR DESCRIPTION
This PR is making the codebase PEP 8 compliant, by linting with the [black linter](https://github.com/psf/black).
Black has found that 76 files need to be changed. 

Why I am proposing this change:
- I spent a lot of time reading code from the codebase in the last few weeks and I have done this for myself to make it more readable. It keeps the long lines and the docstrings tidy so they are more readable to someone new coming. 
- Keeping to PEP 8 standards is good for maintainability and it sets a standard for external people who would like to contribute as they have a guideline to follow. 