### PR TITLE
Making metadata pipenv-compatible

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = clinguin
-version = 0.0.1 beta
+version = 0.0.1-beta
 author = Alexander Beiser, Susana Hahn
 author_email = alexl.id.at@gmail.com, hahnmartin@uni-potsdam.de
 description = An interactive visualizer for clingo


### PR DESCRIPTION
Installing with pipenv would cause the error "Invalid specifier: '==0.0.1 beta'"
replaced the space with a dash, it should be accepted this way