### PR TITLE
cleanup unnecessary dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,14 +16,10 @@ install_requires =
     clorm>=1.4.1
     clingo-dl
     fastapi==0.103.*
-    pydantic
     networkx
     uvicorn
-    httpcore
-    h11
     clingraph
     Pillow
-
 
 [options.package_data]
 * = clinguin/client/presentation/frontends/angular_frontend/clinguin_angular_frontend/*


### PR DESCRIPTION
Just made a pass over dependencies. The project uses pydantic and starlette, which both come with fastapi. The httpcore and h11 modules seem not to be used, as far as I can see. So I would suggest simplifying the deps as follows.