### PR TITLE
Fix: Issue #223

### DIFF
--- a/angular_frontend/package.json
+++ b/angular_frontend/package.json
@@ -35,9 +35,9 @@
     "jasmine-core": "~4.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
-    "karma-coverage": "~2.2.2",
+    "karma-coverage": "~2.2.1",
     "karma-jasmine": "~5.1.0",
-    "karma-jasmine-html-reporter": "~2.2.2",
+    "karma-jasmine-html-reporter": "~2.1.0",
     "typescript": "~5.1.3"
   }
 }


### PR DESCRIPTION
This fixes the versions of `karma-coverage` and `karma-jasmine-html-reporter` to `~2.2.1` and `~2.1.0` respectively.

This fixes #223